### PR TITLE
Implement Syncer.Synced()

### DIFF
--- a/syncer/peer.go
+++ b/syncer/peer.go
@@ -22,6 +22,7 @@ type Peer struct {
 	ConnAddr string
 	Inbound  bool
 	mu       sync.Mutex
+	synced   bool
 	err      error
 }
 
@@ -54,6 +55,19 @@ func (p *Peer) setErr(err error) error {
 func (p *Peer) Close() error {
 	p.setErr(errors.New("closing"))
 	return nil
+}
+
+// Synced returns the peer's sync status.
+func (p *Peer) Synced() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.synced
+}
+
+func (p *Peer) setSynced(synced bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.synced = synced
 }
 
 func (p *Peer) callRPC(r gateway.Object, timeout time.Duration) error {


### PR DESCRIPTION
I need this method, otherwise I have to implement my own Syncer. Later on, it might prove helpful when porting `hostd` and `renterd`, too.
It has been working fine in my tests so far. If needed, `minSyncedPeers` and `minTimeUntilSynceed` can be added to the config options.