### PR TITLE
Add ErrPeerNotFound

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -62,6 +62,8 @@ type PeerStore interface {
 var (
 	// ErrPeerBanned is returned when a peer is banned.
 	ErrPeerBanned = errors.New("peer is banned")
+	// ErrPeerNotFound is returned when the peer is not found.
+	ErrPeerNotFound = errors.New("peer not found")
 )
 
 // Subnet normalizes the provided CIDR subnet string.


### PR DESCRIPTION
`ErrPeerNotFound` is referenced in the docstring to `UpdatePeerInfo` in `PeerStore`. However, it's not implemented yet.
```
// UpdatePeerInfo updates the metadata for the specified peer. If the peer
// is not found, the error should be ErrPeerNotFound.
UpdatePeerInfo(addr string, fn func(*PeerInfo)) error
```