### PR TITLE
Add wallet apply and revert logic to coreutils

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ '1.20', '1.21' ]
+        go-version: [ '1.21', '1.22' ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.sia.tech/coreutils
 
-go 1.21
+go 1.21.6
 
 require (
 	go.etcd.io/bbolt v1.3.8

--- a/testutil/wallet.go
+++ b/testutil/wallet.go
@@ -29,9 +29,9 @@ type (
 	}
 )
 
-func (et *ephemeralWalletUpdateTxn) WalletStateElements() (eles []types.StateElement, _ error) {
+func (et *ephemeralWalletUpdateTxn) WalletStateElements() (elements []types.StateElement, _ error) {
 	for _, se := range et.store.utxos {
-		eles = append(eles, se.StateElement)
+		elements = append(elements, se.StateElement)
 	}
 	return
 }
@@ -133,6 +133,7 @@ func (es *EphemeralWalletStore) Tip() (types.ChainIndex, error) {
 	return es.tip, nil
 }
 
+// ProcessChainApplyUpdate implements chain.Subscriber.
 func (es *EphemeralWalletStore) ProcessChainApplyUpdate(cau *chain.ApplyUpdate, mayCommit bool) error {
 	es.mu.Lock()
 	defer es.mu.Unlock()
@@ -153,6 +154,7 @@ func (es *EphemeralWalletStore) ProcessChainApplyUpdate(cau *chain.ApplyUpdate, 
 	return nil
 }
 
+// ProcessChainRevertUpdate implements chain.Subscriber.
 func (es *EphemeralWalletStore) ProcessChainRevertUpdate(cru *chain.RevertUpdate) error {
 	es.mu.Lock()
 	defer es.mu.Unlock()

--- a/testutil/wallet.go
+++ b/testutil/wallet.go
@@ -72,7 +72,7 @@ func (et *ephemeralWalletUpdateTxn) RemoveSiacoinElements(ids []types.SiacoinOut
 }
 
 func (et *ephemeralWalletUpdateTxn) RevertIndex(index types.ChainIndex) error {
-	// remove any transactions that were added in the reverted block
+	// remove any events that were added in the reverted block
 	filtered := et.store.events[:0]
 	for i := range et.store.events {
 		if et.store.events[i].Index == index {
@@ -92,7 +92,7 @@ func (et *ephemeralWalletUpdateTxn) RevertIndex(index types.ChainIndex) error {
 }
 
 // WalletEvents returns the wallet's events.
-func (es *EphemeralWalletStore) WalletEvents(limit, offset int) ([]wallet.Event, error) {
+func (es *EphemeralWalletStore) WalletEvents(offset, limit int) ([]wallet.Event, error) {
 	es.mu.Lock()
 	defer es.mu.Unlock()
 

--- a/testutil/wallet.go
+++ b/testutil/wallet.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"fmt"
+	"slices"
 	"sync"
 
 	"go.sia.tech/core/types"
@@ -11,192 +12,83 @@ import (
 
 // An EphemeralWalletStore is a Store that does not persist its state to disk. It is
 // primarily useful for testing or as a reference implementation.
-type EphemeralWalletStore struct {
-	privateKey types.PrivateKey
+type (
+	EphemeralWalletStore struct {
+		privateKey types.PrivateKey
 
-	mu          sync.Mutex
-	uncommitted []*chain.ApplyUpdate
-	tip         types.ChainIndex
-	utxos       map[types.Hash256]types.SiacoinElement
+		mu          sync.Mutex
+		uncommitted []*chain.ApplyUpdate
 
-	immaturePayoutTransactions map[uint64][]wallet.Transaction // transactions are never removed to simplify reorg handling
-	transactions               []wallet.Transaction
+		tip          types.ChainIndex
+		utxos        map[types.SiacoinOutputID]wallet.SiacoinElement
+		transactions []wallet.Transaction
+	}
+
+	ephemeralWalletUpdateTxn struct {
+		store *EphemeralWalletStore
+	}
+)
+
+func (et *ephemeralWalletUpdateTxn) WalletStateElements() (eles []types.StateElement, _ error) {
+	for _, se := range et.store.utxos {
+		eles = append(eles, se.StateElement)
+	}
+	return
 }
 
-// ProcessChainRevertUpdate implements chain.Subscriber
-func (es *EphemeralWalletStore) ProcessChainRevertUpdate(cru *chain.RevertUpdate) error {
-	es.mu.Lock()
-	defer es.mu.Unlock()
-
-	// if the update is uncommitted, remove it from the uncommitted list
-	if len(es.uncommitted) > 0 && es.uncommitted[len(es.uncommitted)-1].State.Index == cru.State.Index {
-		es.uncommitted = es.uncommitted[:len(es.uncommitted)-1]
-		return nil
-	}
-
-	walletAddress := types.StandardUnlockHash(es.privateKey.PublicKey())
-
-	// revert any siacoin element changes
-	cru.ForEachSiacoinElement(func(se types.SiacoinElement, spent bool) {
-		if se.SiacoinOutput.Address != walletAddress {
-			return
-		}
-
-		if spent {
-			es.utxos[se.ID] = se
-		} else {
-			delete(es.utxos, se.ID)
-		}
-	})
-
-	// remove any transactions that were added in the reverted block
-	filtered := es.transactions[:0]
-	for _, txn := range es.transactions {
-		if txn.Index == cru.State.Index {
-			continue
-		}
-		filtered = append(filtered, txn)
-	}
-
-	// update element proofs
-	for id, se := range es.utxos {
-		cru.UpdateElementProof(&se.StateElement)
-		es.utxos[id] = se
+func (et *ephemeralWalletUpdateTxn) UpdateStateElements(elements []types.StateElement) error {
+	for _, se := range elements {
+		utxo := et.store.utxos[types.SiacoinOutputID(se.ID)]
+		utxo.StateElement = se
+		et.store.utxos[types.SiacoinOutputID(se.ID)] = utxo
 	}
 	return nil
 }
 
-// ProcessChainApplyUpdate implements chain.Subscriber
-func (es *EphemeralWalletStore) ProcessChainApplyUpdate(cau *chain.ApplyUpdate, commit bool) error {
-	es.mu.Lock()
-	defer es.mu.Unlock()
+func (et *ephemeralWalletUpdateTxn) AddTransactions(transactions []wallet.Transaction) error {
+	// transactions are added in reverse order to make the most recent transaction the first
+	slices.Reverse(transactions)
+	et.store.transactions = append(transactions, et.store.transactions...)
+	return nil
+}
 
-	es.uncommitted = append(es.uncommitted, cau)
-	if !commit {
-		return nil
+func (et *ephemeralWalletUpdateTxn) AddSiacoinElements(elements []wallet.SiacoinElement) error {
+	for _, se := range elements {
+		if _, ok := et.store.utxos[types.SiacoinOutputID(se.ID)]; ok {
+			return fmt.Errorf("siacoin element %q already exists", se.ID)
+		}
+		et.store.utxos[types.SiacoinOutputID(se.ID)] = se
 	}
+	return nil
+}
 
-	walletAddress := types.StandardUnlockHash(es.privateKey.PublicKey())
-
-	for _, update := range es.uncommitted {
-		// cache the source of new immature outputs to show payout transactions
-		siacoinOutputSources := map[types.SiacoinOutputID]wallet.TransactionSource{
-			update.Block.ID().FoundationOutputID(): wallet.TxnSourceFoundationPayout,
+func (et *ephemeralWalletUpdateTxn) RemoveSiacoinElements(ids []types.SiacoinOutputID) error {
+	for _, id := range ids {
+		if _, ok := et.store.utxos[id]; !ok {
+			return fmt.Errorf("siacoin element %q does not exist", id)
 		}
-		// add the miner payouts
-		for i := range update.Block.MinerPayouts {
-			siacoinOutputSources[update.Block.ID().MinerOutputID(i)] = wallet.TxnSourceMinerPayout
+		delete(et.store.utxos, id)
+	}
+	return nil
+}
+
+func (et *ephemeralWalletUpdateTxn) RevertIndex(index types.ChainIndex) error {
+	// remove any transactions that were added in the reverted block
+	filtered := et.store.transactions[:0]
+	for i := range et.store.transactions {
+		if et.store.transactions[i].Index == index {
+			continue
 		}
+		filtered = append(filtered, et.store.transactions[i])
+	}
+	et.store.transactions = filtered
 
-		// add the file contract outputs
-		update.ForEachFileContractElement(func(fce types.FileContractElement, rev *types.FileContractElement, resolved bool, valid bool) {
-			if !resolved {
-				return
-			}
-
-			if valid {
-				for i := range fce.FileContract.ValidProofOutputs {
-					siacoinOutputSources[types.FileContractID(fce.ID).ValidOutputID(i)] = wallet.TxnSourceContract
-				}
-			} else {
-				for i := range fce.FileContract.MissedProofOutputs {
-					siacoinOutputSources[types.FileContractID(fce.ID).MissedOutputID(i)] = wallet.TxnSourceContract
-				}
-			}
-		})
-
-		// add matured transactions first since
-		for _, txn := range es.immaturePayoutTransactions[update.State.Index.Height] {
-			txn.Index = update.State.Index
-			txn.Timestamp = update.Block.Timestamp
-			// prepend the transaction to the wallet
-			es.transactions = append([]wallet.Transaction{txn}, es.transactions...)
-		}
-
-		// add the block transactions
-		for _, txn := range update.Block.Transactions {
-			if !wallet.IsRelevantTransaction(txn, walletAddress) {
-				continue
-			}
-
-			wt := wallet.Transaction{
-				ID:          txn.ID(),
-				Index:       update.State.Index,
-				Transaction: txn,
-				Timestamp:   update.Block.Timestamp,
-				Source:      wallet.TxnSourceTransaction,
-			}
-
-			for _, sci := range txn.SiacoinInputs {
-				if sci.UnlockConditions.UnlockHash() != walletAddress {
-					continue
-				}
-
-				sce, ok := es.utxos[types.Hash256(sci.ParentID)]
-				if !ok {
-					return fmt.Errorf("missing relevant siacoin element %q", sci.ParentID)
-				}
-				wt.Outflow = wt.Outflow.Add(sce.SiacoinOutput.Value)
-			}
-
-			for _, sco := range txn.SiacoinOutputs {
-				if sco.Address != walletAddress {
-					continue
-				}
-
-				wt.Inflow = wt.Inflow.Add(sco.Value)
-			}
-
-			// prepend the transaction to the wallet
-			es.transactions = append([]wallet.Transaction{wt}, es.transactions...)
-
-			// add the siafund claim output IDs
-			for i := range txn.SiafundInputs {
-				siacoinOutputSources[txn.SiafundInputs[i].ParentID.ClaimOutputID()] = wallet.TxnSourceSiafundClaim
-			}
-		}
-
-		// update the utxo set
-		update.ForEachSiacoinElement(func(se types.SiacoinElement, spent bool) {
-			if se.SiacoinOutput.Address != walletAddress {
-				return
-			}
-
-			// update the utxo set
-			if spent {
-				delete(es.utxos, se.ID)
-			} else {
-				es.utxos[se.ID] = se
-			}
-
-			// create an immature payout transaction for any immature siacoin outputs
-			if se.MaturityHeight == 0 || spent {
-				return
-			}
-
-			source, ok := siacoinOutputSources[types.SiacoinOutputID(se.ID)]
-			if !ok {
-				panic("missing siacoin source")
-			}
-
-			es.immaturePayoutTransactions[se.MaturityHeight] = append(es.immaturePayoutTransactions[se.MaturityHeight], wallet.Transaction{
-				ID:          types.TransactionID(se.ID),
-				Transaction: types.Transaction{SiacoinOutputs: []types.SiacoinOutput{se.SiacoinOutput}},
-				Inflow:      se.SiacoinOutput.Value,
-				Source:      source,
-				// Index and Timestamp will be filled in later
-			})
-		})
-
-		// update the element proofs
-		for id, se := range es.utxos {
-			cau.UpdateElementProof(&se.StateElement)
-			es.utxos[id] = se
+	// remove any siacoin elements that were added in the reverted block
+	for id, se := range et.store.utxos {
+		if se.Index == index {
+			delete(et.store.utxos, id)
 		}
 	}
-
-	es.uncommitted = es.uncommitted[:0]
-	es.tip = cau.State.Index
 	return nil
 }
 
@@ -224,7 +116,7 @@ func (es *EphemeralWalletStore) TransactionCount() (uint64, error) {
 }
 
 // UnspentSiacoinElements returns the wallet's unspent siacoin outputs.
-func (es *EphemeralWalletStore) UnspentSiacoinElements() (utxos []types.SiacoinElement, _ error) {
+func (es *EphemeralWalletStore) UnspentSiacoinElements() (utxos []wallet.SiacoinElement, _ error) {
 	es.mu.Lock()
 	defer es.mu.Unlock()
 
@@ -241,12 +133,45 @@ func (es *EphemeralWalletStore) Tip() (types.ChainIndex, error) {
 	return es.tip, nil
 }
 
+func (es *EphemeralWalletStore) ProcessChainApplyUpdate(cau *chain.ApplyUpdate, mayCommit bool) error {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+
+	es.uncommitted = append(es.uncommitted, cau)
+	if !mayCommit {
+		return nil
+	}
+
+	address := types.StandardUnlockHash(es.privateKey.PublicKey())
+	ephemeralWalletUpdateTxn := &ephemeralWalletUpdateTxn{store: es}
+
+	if err := wallet.ApplyChainUpdates(ephemeralWalletUpdateTxn, address, es.uncommitted); err != nil {
+		return err
+	}
+	es.tip = cau.State.Index
+	es.uncommitted = nil
+	return nil
+}
+
+func (es *EphemeralWalletStore) ProcessChainRevertUpdate(cru *chain.RevertUpdate) error {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+
+	if len(es.uncommitted) > 0 && es.uncommitted[len(es.uncommitted)-1].State.Index == cru.State.Index {
+		es.uncommitted = es.uncommitted[:len(es.uncommitted)-1]
+		return nil
+	}
+
+	address := types.StandardUnlockHash(es.privateKey.PublicKey())
+	return wallet.RevertChainUpdate(&ephemeralWalletUpdateTxn{store: es}, address, cru)
+}
+
 // NewEphemeralWalletStore returns a new EphemeralWalletStore.
 func NewEphemeralWalletStore(pk types.PrivateKey) *EphemeralWalletStore {
 	return &EphemeralWalletStore{
 		privateKey: pk,
 
-		utxos:                      make(map[types.Hash256]types.SiacoinElement),
-		immaturePayoutTransactions: make(map[uint64][]wallet.Transaction),
+		utxos:        make(map[types.SiacoinOutputID]wallet.SiacoinElement),
+		transactions: make([]wallet.Transaction, 0),
 	}
 }

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -1,0 +1,278 @@
+package wallet
+
+import (
+	"fmt"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/coreutils/chain"
+)
+
+type (
+	// ApplyTx is an interface for atomically applying a chain update to a
+	// single address wallet.
+	ApplyTx interface {
+		// WalletStateElements returns all state elements related to the wallet. It is used
+		// to update the proofs of all state elements affected by the update.
+		WalletStateElements() ([]types.StateElement, error)
+		// UpdateStateElements updates the proofs of all state elements affected by the
+		// update.
+		UpdateStateElements([]types.StateElement) error
+
+		// AddTransactions is called with all transactions added in the update.
+		AddTransactions([]Transaction) error
+		// AddSiacoinElements is called with all new siacoin elements in the
+		// update. Ephemeral siacoin elements are not included.
+		AddSiacoinElements([]SiacoinElement) error
+		// RemoveSiacoinElements is called with all siacoin elements that were
+		// spent in the update.
+		RemoveSiacoinElements([]types.SiacoinOutputID) error
+	}
+
+	// RevertTx is an interface for atomically reverting a chain update from a
+	// single address wallet.
+	RevertTx interface {
+		// WalletStateElements returns all state elements in the database. It is used
+		// to update the proofs of all state elements affected by the update.
+		WalletStateElements() ([]types.StateElement, error)
+		// UpdateStateElements updates the proofs of all state elements affected by the
+		// update.
+		UpdateStateElements([]types.StateElement) error
+
+		// RevertIndex is called with the chain index that is being reverted.
+		// Any transactions and siacoin elements that were created by the index
+		// should be removed.
+		RevertIndex(types.ChainIndex) error
+		// AddSiacoinElements is called with all siacoin elements that are
+		// now unspent due to the revert.
+		AddSiacoinElements([]SiacoinElement) error
+	}
+)
+
+// addressPayoutTransactions is a helper to add all payout transactions from an
+// apply update to a slice of transactions.
+func addressPayoutTransactions(addr types.Address, cau *chain.ApplyUpdate) (transactions []Transaction) {
+	index := cau.State.Index
+	state := cau.State
+	block := cau.Block
+
+	// cache the source of new immature outputs to show payout transactions
+	if state.FoundationPrimaryAddress == addr {
+		transactions = append(transactions, Transaction{
+			ID:    types.TransactionID(index.ID.FoundationOutputID()),
+			Index: index,
+			Transaction: types.Transaction{
+				SiacoinOutputs: []types.SiacoinOutput{
+					state.FoundationSubsidy(),
+				},
+			},
+			Inflow:    state.FoundationSubsidy().Value,
+			Source:    TxnSourceFoundationPayout,
+			Timestamp: block.Timestamp,
+		})
+	}
+
+	// add the miner payouts
+	for i := range block.MinerPayouts {
+		if block.MinerPayouts[i].Address != addr {
+			continue
+		}
+
+		transactions = append(transactions, Transaction{
+			ID:    types.TransactionID(index.ID.MinerOutputID(i)),
+			Index: index,
+			Transaction: types.Transaction{
+				SiacoinOutputs: []types.SiacoinOutput{
+					block.MinerPayouts[i],
+				},
+			},
+			Inflow:         block.MinerPayouts[i].Value,
+			MaturityHeight: state.MaturityHeight(),
+			Source:         TxnSourceMinerPayout,
+			Timestamp:      block.Timestamp,
+		})
+	}
+
+	// add the file contract outputs
+	cau.ForEachFileContractElement(func(fce types.FileContractElement, rev *types.FileContractElement, resolved bool, valid bool) {
+		if !resolved {
+			return
+		}
+
+		if valid {
+			for i, output := range fce.FileContract.ValidProofOutputs {
+				if output.Address != addr {
+					continue
+				}
+
+				outputID := types.FileContractID(fce.ID).ValidOutputID(i)
+				transactions = append(transactions, Transaction{
+					ID:    types.TransactionID(outputID),
+					Index: index,
+					Transaction: types.Transaction{
+						SiacoinOutputs: []types.SiacoinOutput{output},
+						FileContracts:  []types.FileContract{fce.FileContract},
+					},
+					Inflow:         fce.FileContract.ValidProofOutputs[i].Value,
+					MaturityHeight: state.MaturityHeight(),
+					Source:         TxnSourceValidContract,
+					Timestamp:      block.Timestamp,
+				})
+			}
+		} else {
+			for i, output := range fce.FileContract.MissedProofOutputs {
+				if output.Address != addr {
+					continue
+				}
+
+				outputID := types.FileContractID(fce.ID).MissedOutputID(i)
+				transactions = append(transactions, Transaction{
+					ID:    types.TransactionID(outputID),
+					Index: index,
+					Transaction: types.Transaction{
+						SiacoinOutputs: []types.SiacoinOutput{output},
+						FileContracts:  []types.FileContract{fce.FileContract},
+					},
+					Inflow:         fce.FileContract.ValidProofOutputs[i].Value,
+					MaturityHeight: state.MaturityHeight(),
+					Source:         TxnSourceMissedContract,
+					Timestamp:      block.Timestamp,
+				})
+			}
+		}
+	})
+	return
+}
+
+// ApplyChainUpdates atomically applies a batch of wallet updates
+func ApplyChainUpdates(tx ApplyTx, address types.Address, updates []*chain.ApplyUpdate) error {
+	stateElements, err := tx.WalletStateElements()
+	if err != nil {
+		return fmt.Errorf("failed to get state elements: %w", err)
+	}
+
+	var transactions []Transaction
+	var spentUTXOs []types.SiacoinOutputID
+	newUTXOs := make(map[types.Hash256]SiacoinElement)
+
+	for _, cau := range updates {
+		transactions = append(transactions, addressPayoutTransactions(address, cau)...)
+		utxoValues := make(map[types.SiacoinOutputID]types.Currency)
+
+		cau.ForEachSiacoinElement(func(se types.SiacoinElement, spent bool) {
+			if se.SiacoinOutput.Address != address {
+				return
+			}
+
+			// cache the value of the utxo to use when calculating outflow
+			utxoValues[types.SiacoinOutputID(se.ID)] = se.SiacoinOutput.Value
+			if spent {
+				// remove the utxo from the new utxos
+				delete(newUTXOs, se.ID)
+
+				// skip ephemeral outputs
+				if se.StateElement.LeafIndex != types.EphemeralLeafIndex {
+					spentUTXOs = append(spentUTXOs, types.SiacoinOutputID(se.ID))
+				}
+			} else {
+				newUTXOs[se.ID] = SiacoinElement{
+					SiacoinElement: se,
+					Index:          cau.State.Index,
+				}
+			}
+		})
+
+		for _, txn := range cau.Block.Transactions {
+			wtx := Transaction{
+				ID:          txn.ID(),
+				Index:       cau.State.Index,
+				Transaction: txn,
+				Source:      TxnSourceTransaction,
+				Timestamp:   cau.Block.Timestamp,
+			}
+
+			for _, si := range txn.SiacoinInputs {
+				if si.UnlockConditions.UnlockHash() == address {
+					value, ok := utxoValues[si.ParentID]
+					if !ok {
+						panic("missing utxo") // this should never happen
+					}
+					wtx.Inflow = wtx.Inflow.Add(value)
+				}
+			}
+
+			for _, so := range txn.SiacoinOutputs {
+				if so.Address != address {
+					continue
+				}
+				wtx.Outflow = wtx.Outflow.Add(so.Value)
+			}
+
+			// skip irrelevant transactions
+			if wtx.Inflow.IsZero() && wtx.Outflow.IsZero() {
+				continue
+			}
+
+			transactions = append(transactions, wtx)
+		}
+
+		for i := range stateElements {
+			cau.UpdateElementProof(&stateElements[i])
+		}
+
+		for _, se := range newUTXOs {
+			cau.UpdateElementProof(&se.StateElement)
+		}
+	}
+
+	createdUTXOs := make([]SiacoinElement, 0, len(newUTXOs))
+	for _, se := range newUTXOs {
+		createdUTXOs = append(createdUTXOs, se)
+	}
+
+	if err := tx.AddSiacoinElements(createdUTXOs); err != nil {
+		return fmt.Errorf("failed to add siacoin elements: %w", err)
+	} else if err := tx.RemoveSiacoinElements(spentUTXOs); err != nil {
+		return fmt.Errorf("failed to remove siacoin elements: %w", err)
+	} else if err := tx.AddTransactions(transactions); err != nil {
+		return fmt.Errorf("failed to add transactions: %w", err)
+	} else if err := tx.UpdateStateElements(stateElements); err != nil {
+		return fmt.Errorf("failed to update state elements: %w", err)
+	}
+	return nil
+}
+
+// RevertChainUpdate atomically reverts a chain update from a wallet
+func RevertChainUpdate(tx RevertTx, address types.Address, cru *chain.RevertUpdate) error {
+	stateElements, err := tx.WalletStateElements()
+	if err != nil {
+		return fmt.Errorf("failed to get state elements: %w", err)
+	}
+
+	var readdedUTXOs []SiacoinElement
+
+	cru.ForEachSiacoinElement(func(se types.SiacoinElement, spent bool) {
+		if se.SiacoinOutput.Address != address {
+			return
+		}
+
+		if !spent {
+			readdedUTXOs = append(readdedUTXOs, SiacoinElement{
+				SiacoinElement: se,
+				Index:          cru.State.Index,
+			})
+		}
+	})
+
+	for i := range stateElements {
+		cru.UpdateElementProof(&stateElements[i])
+	}
+
+	if err := tx.RevertIndex(cru.State.Index); err != nil {
+		return fmt.Errorf("failed to revert block: %w", err)
+	} else if err := tx.AddSiacoinElements(readdedUTXOs); err != nil {
+		return fmt.Errorf("failed to add siacoin elements: %w", err)
+	} else if err := tx.UpdateStateElements(stateElements); err != nil {
+		return fmt.Errorf("failed to update state elements: %w", err)
+	}
+	return nil
+}

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -235,7 +235,7 @@ func ApplyChainUpdates(tx ApplyTx, address types.Address, updates []*chain.Apply
 	} else if err := tx.RemoveSiacoinElements(spentUTXOs); err != nil {
 		return fmt.Errorf("failed to remove siacoin elements: %w", err)
 	} else if err := tx.AddEvents(events); err != nil {
-		return fmt.Errorf("failed to add transactions: %w", err)
+		return fmt.Errorf("failed to add events: %w", err)
 	} else if err := tx.UpdateStateElements(stateElements); err != nil {
 		return fmt.Errorf("failed to update state elements: %w", err)
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -42,7 +42,7 @@ var (
 )
 
 type (
-	// A TransactionSource is a string indicating the source of a transaction.
+	// An EventSource is a string indicating the source of a transaction.
 	EventSource string
 
 	// An Event is a transaction or other event that affects the wallet including

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -97,7 +97,7 @@ type (
 		// WalletEvents returns a paginated list of transactions ordered by
 		// maturity height, descending. If no more transactions are available,
 		// (nil, nil) should be returned.
-		WalletEvents(limit, offset int) ([]Event, error)
+		WalletEvents(offset, limit int) ([]Event, error)
 		// WalletEventCount returns the total number of events relevant to the
 		// wallet.
 		WalletEventCount() (uint64, error)
@@ -215,8 +215,8 @@ func (sw *SingleAddressWallet) Balance() (balance Balance, err error) {
 
 // Events returns a paginated list of events, ordered by maturity height, descending.
 // If no more events are available, (nil, nil) is returned.
-func (sw *SingleAddressWallet) Events(limit, offset int) ([]Event, error) {
-	return sw.store.WalletEvents(limit, offset)
+func (sw *SingleAddressWallet) Events(offset, limit int) ([]Event, error) {
+	return sw.store.WalletEvents(offset, limit)
 }
 
 // EventCount returns the total number of events relevant to the wallet.

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -68,7 +68,7 @@ func TestWallet(t *testing.T) {
 
 	maturityHeight := cm.TipState().MaturityHeight()
 	// check that the wallet has a single event
-	if events, err := w.Events(100, 0); err != nil {
+	if events, err := w.Events(0, 100); err != nil {
 		t.Fatal(err)
 	} else if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %v", len(events))
@@ -107,7 +107,7 @@ func TestWallet(t *testing.T) {
 	}
 
 	// check that the payout transaction was created
-	events, err := w.Events(100, 0)
+	events, err := w.Events(0, 100)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(events) != 1 {
@@ -195,7 +195,7 @@ func TestWallet(t *testing.T) {
 	}
 
 	// check that the paginated transactions are in the proper order
-	events, err = w.Events(100, 0)
+	events, err = w.Events(0, 100)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(events) != 2 {
@@ -213,7 +213,6 @@ func TestWallet(t *testing.T) {
 		sent[i].SiacoinOutputs = []types.SiacoinOutput{
 			{Address: types.VoidAddress, Value: sendAmount},
 		}
-
 		toSign, err := w.FundTransaction(&sent[i], sendAmount, false)
 		if err != nil {
 			t.Fatal(err)
@@ -246,7 +245,7 @@ func TestWallet(t *testing.T) {
 	}
 
 	// check that the paginated transactions are in the proper order
-	events, err = w.Events(20, 0) // limit of 20 so the original two transactions are not included
+	events, err = w.Events(0, 20) // limit of 20 so the original two transactions are not included
 	if err != nil {
 		t.Fatal(err)
 	} else if len(events) != 20 {


### PR DESCRIPTION
This adds subscriber logic to the wallet package. Instead of duplicating the single address transaction and utxo logic, stores can implement the transaction interface and call `wallet.ApplyChainUpdates` and `wallet.RevertChainUpdate` from their consensus subscriber.