### PR TITLE
Overhaul subscription API

### DIFF
--- a/miner_test.go
+++ b/miner_test.go
@@ -26,7 +26,6 @@ func TestMiner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.Close()
 	cm := chain.NewManager(store, tipState)
 
 	// create a transaction

--- a/testutil/network.go
+++ b/testutil/network.go
@@ -17,8 +17,8 @@ func Network() (*consensus.Network, types.Block) {
 	n.HardforkOak.Height = 1
 	n.HardforkASIC.Height = 1
 	n.HardforkFoundation.Height = 1
-	n.HardforkV2.AllowHeight = 100
-	n.HardforkV2.RequireHeight = 150
+	n.HardforkV2.AllowHeight = 200 // comfortably above MaturityHeight
+	n.HardforkV2.RequireHeight = 250
 	return n, genesisBlock
 }
 

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -50,7 +50,7 @@ type (
 
 // addressPayoutEvents is a helper to add all payout transactions from an
 // apply update to a slice of transactions.
-func addressPayoutEvents(addr types.Address, cau *chain.ApplyUpdate) (events []Event) {
+func addressPayoutEvents(addr types.Address, cau chain.ApplyUpdate) (events []Event) {
 	index := cau.State.Index
 	state := cau.State
 	block := cau.Block
@@ -144,7 +144,7 @@ func addressPayoutEvents(addr types.Address, cau *chain.ApplyUpdate) (events []E
 }
 
 // ApplyChainUpdates atomically applies a batch of wallet updates
-func ApplyChainUpdates(tx ApplyTx, address types.Address, updates []*chain.ApplyUpdate) error {
+func ApplyChainUpdates(tx ApplyTx, address types.Address, updates []chain.ApplyUpdate) error {
 	stateElements, err := tx.WalletStateElements()
 	if err != nil {
 		return fmt.Errorf("failed to get state elements: %w", err)
@@ -243,7 +243,7 @@ func ApplyChainUpdates(tx ApplyTx, address types.Address, updates []*chain.Apply
 }
 
 // RevertChainUpdate atomically reverts a chain update from a wallet
-func RevertChainUpdate(tx RevertTx, address types.Address, cru *chain.RevertUpdate) error {
+func RevertChainUpdate(tx RevertTx, address types.Address, cru chain.RevertUpdate) error {
 	stateElements, err := tx.WalletStateElements()
 	if err != nil {
 		return fmt.Errorf("failed to get state elements: %w", err)


### PR DESCRIPTION
This replaces the one-at-a-time callback-style subscription architecture with a batched, subscriber-directed architecture.

In the old model:
1. Subscribers register themselves with the `chain.Manager`. During initial registration, all updates on the "path" between the subscribers tip and the manager's tip are passed to the subscriber. The manager's lock is held throughout.
2. After all subscribers are registered, we are in a quiescent state until a new block arrives.
3. The syncer receives a block and passes it to the `chain.Manager`.
4. The manager accepts the block, triggering a reorg, necessitating a sequence of reverting and applying blocks.
5. For each block reverted or applied, the manager calls `ProcessChainUpdate` on each subscriber. This occurs in a single goroutine, and the manager's lock is held throughout the entire reorg process.
6. Subscribers are only allowed to commit updates when the manager says so.

In the new model:
1. Subscribers repeatedly call the `(Manager).UpdatesSince` method until their tip matches the manager's tip. The manager's lock is only held while computing updates, not while subscribers are processing them.
2. Subscribers may register an `OnReorg` function with the `chain.Manager`, but this is not strictly necessary.
3. As before, the syncer receives a block, triggering a reorg. The manager reverts and applies blocks as necessary. The manager's lock is held until the reorg is complete.
4.  Subscribers become aware of the reorg (via `OnReorg`, polling, a user-triggered check, etc.). Each subscriber then calls `UpdatesSince` until their tip matches the manager's tip. This typically happens in a separate goroutine (though tests may eschew this for simplicity).
5. Subscribers may commit updates at any time.

The new model enables greater parallelism across subscribers, gives subscribers more control over their commit frequency, and allows subscribers to call arbitrary `chain.Manager` methods while processing updates. Its primary downside is that it shift lifecycle management to subscribers, making them responsible for spawning and terminating goroutines. So it *should* be a win on net, but I'm not going to merge yet; we should try adapting `walletd` to this API and see how that plays out first.

Not addressed here: block pruning. In the old model, the manager can be confident when a block is no longer needed by any subscriber, and can thus safely prune it. This is no longer true in the new model, so we need a different approach. I'm leaning towards ~~punting the problem to a higher layer~~  an *explicit API* where the system that orchestrates the various subscribers also informs the manager when particular blocks can be pruned. We'll see.

