### PR TITLE
Fix 'inUse' condition in wallet.Redistribute

### DIFF
--- a/testutil/network.go
+++ b/testutil/network.go
@@ -22,7 +22,8 @@ func Network() (*consensus.Network, types.Block) {
 	return n, genesisBlock
 }
 
-// MineBlock mines a block with the given transactions.
+// MineBlock mines a block with the given transactions, transaction fees are
+// added to the miner payout.
 func MineBlock(cm *chain.Manager, minerAddress types.Address) types.Block {
 	var minerFees types.Currency
 	for _, txn := range cm.PoolTransactions() {

--- a/testutil/network.go
+++ b/testutil/network.go
@@ -24,12 +24,17 @@ func Network() (*consensus.Network, types.Block) {
 
 // MineBlock mines a block with the given transactions.
 func MineBlock(cm *chain.Manager, minerAddress types.Address) types.Block {
+	var minerFees types.Currency
+	for _, txn := range cm.PoolTransactions() {
+		minerFees = minerFees.Add(txn.TotalFees())
+	}
+
 	state := cm.TipState()
 	b := types.Block{
 		ParentID:     state.Index.ID,
 		Timestamp:    types.CurrentTimestamp(),
 		Transactions: cm.PoolTransactions(),
-		MinerPayouts: []types.SiacoinOutput{{Address: minerAddress, Value: state.BlockReward()}},
+		MinerPayouts: []types.SiacoinOutput{{Address: minerAddress, Value: state.BlockReward().Add(minerFees)}},
 	}
 	for b.ID().CmpWork(state.ChildTarget) < 0 {
 		b.Nonce += state.NonceFactor()

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -496,7 +496,7 @@ func (sw *SingleAddressWallet) Redistribute(outputs int, amount, feePerByte type
 	// unused, matured and has the same value
 	utxos := make([]types.SiacoinElement, 0, len(elements))
 	for _, sce := range elements {
-		inUse := time.Now().After(sw.locked[sce.ID]) || inPool[sce.ID]
+		inUse := time.Now().Before(sw.locked[sce.ID]) || inPool[sce.ID]
 		matured := bh >= sce.MaturityHeight
 		sameValue := sce.SiacoinOutput.Value.Equals(amount)
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -297,8 +297,14 @@ func (sw *SingleAddressWallet) FundTransaction(txn *types.Transaction, amount ty
 	// remove immature, locked and spent outputs
 	cs := sw.cm.TipState()
 	utxos := make([]types.SiacoinElement, 0, len(elements))
+	var usedSum types.Currency
+	var immatureSum types.Currency
 	for _, sce := range elements {
-		if sw.isLocked(sce.ID) || tpoolSpent[sce.ID] || cs.Index.Height < sce.MaturityHeight {
+		if used := sw.isLocked(sce.ID) || tpoolSpent[sce.ID]; used {
+			usedSum = usedSum.Add(sce.SiacoinOutput.Value)
+			continue
+		} else if immature := cs.Index.Height < sce.MaturityHeight; immature {
+			immatureSum = immatureSum.Add(sce.SiacoinOutput.Value)
 			continue
 		}
 		utxos = append(utxos, sce.SiacoinElement)
@@ -310,19 +316,21 @@ func (sw *SingleAddressWallet) FundTransaction(txn *types.Transaction, amount ty
 	})
 
 	var unconfirmedUTXOs []types.SiacoinElement
+	var unconfirmedSum types.Currency
 	if useUnconfirmed {
 		for _, sce := range tpoolUtxos {
 			if sce.SiacoinOutput.Address != sw.addr || sw.isLocked(sce.ID) {
 				continue
 			}
 			unconfirmedUTXOs = append(unconfirmedUTXOs, sce)
+			unconfirmedSum = unconfirmedSum.Add(sce.SiacoinOutput.Value)
 		}
-
-		// sort by value, descending
-		sort.Slice(unconfirmedUTXOs, func(i, j int) bool {
-			return unconfirmedUTXOs[i].SiacoinOutput.Value.Cmp(unconfirmedUTXOs[j].SiacoinOutput.Value) > 0
-		})
 	}
+
+	// sort by value, descending
+	sort.Slice(unconfirmedUTXOs, func(i, j int) bool {
+		return unconfirmedUTXOs[i].SiacoinOutput.Value.Cmp(unconfirmedUTXOs[j].SiacoinOutput.Value) > 0
+	})
 
 	// fund the transaction using the largest utxos first
 	var selected []types.SiacoinElement
@@ -339,19 +347,19 @@ func (sw *SingleAddressWallet) FundTransaction(txn *types.Transaction, amount ty
 	if inputSum.Cmp(amount) < 0 && useUnconfirmed {
 		// try adding unconfirmed utxos.
 		for _, sce := range unconfirmedUTXOs {
+			selected = append(selected, sce)
+			inputSum = inputSum.Add(sce.SiacoinOutput.Value)
 			if inputSum.Cmp(amount) >= 0 {
 				break
 			}
-			selected = append(selected, sce)
-			inputSum = inputSum.Add(sce.SiacoinOutput.Value)
 		}
 
 		if inputSum.Cmp(amount) < 0 {
 			// still not enough funds
-			return nil, ErrNotEnoughFunds
+			return nil, fmt.Errorf("%w: inputs %v < needed %v (used: %v immature: %v unconfirmed: %v)", ErrNotEnoughFunds, inputSum.String(), amount.String(), usedSum.String(), immatureSum.String(), unconfirmedSum.String())
 		}
 	} else if inputSum.Cmp(amount) < 0 {
-		return nil, ErrNotEnoughFunds
+		return nil, fmt.Errorf("%w: inputs %v < needed %v (used: %v immature: %v", ErrNotEnoughFunds, inputSum.String(), amount.String(), usedSum.String(), immatureSum.String())
 	}
 
 	// check if remaining utxos should be defragged

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -170,7 +170,7 @@ func TestWallet(t *testing.T) {
 
 	// try funding the transaction, expect it to fail since the outputs are immature
 	_, err := w.FundTransaction(&txn, initialReward, false)
-	if err != wallet.ErrNotEnoughFunds {
+	if !errors.Is(err, wallet.ErrNotEnoughFunds) {
 		t.Fatal("expected ErrNotEnoughFunds, got", err)
 	}
 


### PR DESCRIPTION
Oversight in the `inUse` condition, `time.After` vs `time.Before` bug, should've been caught so added a regression test.