### PR TITLE
Add context to every method in the PeerStore interface

### DIFF
--- a/syncer/peer.go
+++ b/syncer/peer.go
@@ -223,7 +223,7 @@ func (p *Peer) acceptRPC() (types.Specifier, *gateway.Stream, error) {
 func (s *Syncer) handleRPC(id types.Specifier, stream *gateway.Stream, origin *Peer) error {
 	switch r := gateway.ObjectForID(id).(type) {
 	case *gateway.RPCShareNodes:
-		peers, err := s.pm.Peers()
+		peers, err := s.pm.Peers(s.shutdownCtx)
 		if err != nil {
 			return fmt.Errorf("failed to fetch peers: %w", err)
 		} else if n := len(peers); n > 10 {


### PR DESCRIPTION
I think every `XStore` method should have a context. We might not care all the time but someone implementing the Store interface themselves might and not accepting a context might create inconsistent code on their side (running into this in `renterd`) In the syncer I could use the new `shutdownCtx`, applied a generous 5' timeout here and there which I think is fine but open to suggestions.