### PR TITLE
Update `gocritic` enabled/disabled checks to fix linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,7 +60,6 @@ linters-settings:
       - style
     disabled-checks:
       # diagnostic
-      - appendAssign
       - commentedOutCode
       - uncheckedInlineErr
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,13 +17,6 @@ run:
   # list of build tags, all linters use it. Default is empty list.
   build-tags: []
 
-  # which dirs to skip: issues from them won't be reported;
-  # can use regexp here: generated.*, regexp is applied on full path;
-  # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
-    - cover
-
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
   skip-dirs-use-default: true
@@ -36,9 +29,6 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
@@ -65,23 +55,28 @@ linters-settings:
     # See https://go-critic.github.io/overview#checks-overview
     # To check which checks are enabled run `GL_DEBUG=gocritic golangci-lint run`
     # By default list of stable checks is used.
-    enabled-checks:
-      - argOrder # Diagnostic options
-      - badCond
-      - caseOrder
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - nilValReturn
-      - offBy1
-      - weakCond
-      - boolExprSimplify # Style options here and below.
-      - builtinShadow
-      - emptyFallthrough
-      - hexLiteral
-      - underef
-      - equalFold
+    enabled-tags:
+      - diagnostic
+      - style
+    disabled-checks:
+      # diagnostic
+      - commentedOutCode
+      - uncheckedInlineErr
+
+      # style
+      - exitAfterDefer
+      - ifElseChain
+      - importShadow
+      - octalLiteral
+      - paramTypeCombine
+      - ptrToRefParam
+      - stringsCompare
+      - tooManyResultsChecker
+      - typeDefFirst
+      - typeUnparen
+      - unlabelStmt
+      - unnamedResult
+      - whyNoLint
   revive:
     ignore-generated-header: true
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters-settings:
       - style
     disabled-checks:
       # diagnostic
+      - appendAssign
       - commentedOutCode
       - uncheckedInlineErr
 
@@ -67,6 +68,8 @@ linters-settings:
       - exitAfterDefer
       - ifElseChain
       - importShadow
+      - initClause
+      - nestingReduce
       - octalLiteral
       - paramTypeCombine
       - ptrToRefParam

--- a/chain/db.go
+++ b/chain/db.go
@@ -402,14 +402,13 @@ func (db *DBStore) deleteFileContractExpiration(id types.FileContractID, windowE
 	key := db.encHeight(windowEnd)
 	val := append([]byte(nil), b.getRaw(key)...)
 	for i := 0; i < len(val); i += 32 {
-		if *(*types.FileContractID)(val[i:]) != id {
-			continue
+		if *(*types.FileContractID)(val[i:]) == id {
+			copy(val[i:], val[len(val)-32:])
+			val = val[:len(val)-32]
+			i -= 32
+			b.putRaw(key, val)
+			return
 		}
-		copy(val[i:], val[len(val)-32:])
-		val = val[:len(val)-32]
-		i -= 32
-		b.putRaw(key, val)
-		return
 	}
 	panic("missing file contract expiration")
 }

--- a/chain/db.go
+++ b/chain/db.go
@@ -402,13 +402,14 @@ func (db *DBStore) deleteFileContractExpiration(id types.FileContractID, windowE
 	key := db.encHeight(windowEnd)
 	val := append([]byte(nil), b.getRaw(key)...)
 	for i := 0; i < len(val); i += 32 {
-		if *(*types.FileContractID)(val[i:]) == id {
-			copy(val[i:], val[len(val)-32:])
-			val = val[:len(val)-32]
-			i -= 32
-			b.putRaw(key, val)
-			return
+		if *(*types.FileContractID)(val[i:]) != id {
+			continue
 		}
+		copy(val[i:], val[len(val)-32:])
+		val = val[:len(val)-32]
+		i -= 32
+		b.putRaw(key, val)
+		return
 	}
 	panic("missing file contract expiration")
 }

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -513,7 +513,8 @@ func (m *Manager) revalidatePool() {
 		delete(m.txpool.indices, txid)
 	}
 	m.txpool.ms = consensus.NewMidState(m.tipState)
-	txns := append(m.txpool.txns, m.txpool.lastReverted...)
+	txns := m.txpool.txns
+	txns = append(txns, m.txpool.lastReverted...)
 	m.txpool.txns = m.txpool.txns[:0]
 	m.txpool.weight = 0
 	for _, txn := range txns {
@@ -525,7 +526,8 @@ func (m *Manager) revalidatePool() {
 			m.txpool.weight += m.tipState.TransactionWeight(txn)
 		}
 	}
-	v2txns := append(m.txpool.v2txns, m.txpool.lastRevertedV2...)
+	v2txns := m.txpool.v2txns
+	v2txns = append(v2txns, m.txpool.lastRevertedV2...)
 	m.txpool.v2txns = m.txpool.v2txns[:0]
 	for _, txn := range v2txns {
 		if consensus.ValidateV2Transaction(m.txpool.ms, txn) == nil {
@@ -806,7 +808,8 @@ func (m *Manager) TransactionsForPartialBlock(missing []types.Hash256) (txns []t
 	for _, txn := range m.txpool.txns {
 		if h := txn.FullHash(); want[h] {
 			txns = append(txns, txn)
-			if delete(want, h); len(want) == 0 {
+			delete(want, h)
+			if len(want) == 0 {
 				return
 			}
 		}
@@ -814,7 +817,8 @@ func (m *Manager) TransactionsForPartialBlock(missing []types.Hash256) (txns []t
 	for _, txn := range m.txpool.v2txns {
 		if h := txn.FullHash(); want[h] {
 			v2txns = append(v2txns, txn)
-			if delete(want, h); len(want) == 0 {
+			delete(want, h)
+			if len(want) == 0 {
 				return
 			}
 		}

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -513,8 +513,7 @@ func (m *Manager) revalidatePool() {
 		delete(m.txpool.indices, txid)
 	}
 	m.txpool.ms = consensus.NewMidState(m.tipState)
-	txns := m.txpool.txns
-	txns = append(txns, m.txpool.lastReverted...)
+	txns := append(m.txpool.txns, m.txpool.lastReverted...)
 	m.txpool.txns = m.txpool.txns[:0]
 	m.txpool.weight = 0
 	for _, txn := range txns {
@@ -526,8 +525,7 @@ func (m *Manager) revalidatePool() {
 			m.txpool.weight += m.tipState.TransactionWeight(txn)
 		}
 	}
-	v2txns := m.txpool.v2txns
-	v2txns = append(v2txns, m.txpool.lastRevertedV2...)
+	v2txns := append(m.txpool.v2txns, m.txpool.lastRevertedV2...)
 	m.txpool.v2txns = m.txpool.v2txns[:0]
 	for _, txn := range v2txns {
 		if consensus.ValidateV2Transaction(m.txpool.ms, txn) == nil {
@@ -808,8 +806,7 @@ func (m *Manager) TransactionsForPartialBlock(missing []types.Hash256) (txns []t
 	for _, txn := range m.txpool.txns {
 		if h := txn.FullHash(); want[h] {
 			txns = append(txns, txn)
-			delete(want, h)
-			if len(want) == 0 {
+			if delete(want, h); len(want) == 0 {
 				return
 			}
 		}
@@ -817,8 +814,7 @@ func (m *Manager) TransactionsForPartialBlock(missing []types.Hash256) (txns []t
 	for _, txn := range m.txpool.v2txns {
 		if h := txn.FullHash(); want[h] {
 			v2txns = append(v2txns, txn)
-			delete(want, h)
-			if len(want) == 0 {
+			if delete(want, h); len(want) == 0 {
 				return
 			}
 		}


### PR DESCRIPTION
This PR adjusts our linter so it passes again after upgrading `golangci` to `v1.57.0`. 