### PR TITLE
Cache ephemeral utxo values

### DIFF
--- a/wallet/update.go
+++ b/wallet/update.go
@@ -158,12 +158,18 @@ func applyChainState(tx UpdateTx, address types.Address, cau chain.ApplyUpdate) 
 	utxoValues := make(map[types.SiacoinOutputID]types.Currency)
 
 	cau.ForEachSiacoinElement(func(se types.SiacoinElement, spent bool) {
-		if se.SiacoinOutput.Address != address || ephemeral[types.Hash256(se.ID)] {
+		if se.SiacoinOutput.Address != address {
 			return
 		}
 
 		// cache the value of the utxo to use when calculating outflow
 		utxoValues[types.SiacoinOutputID(se.ID)] = se.SiacoinOutput.Value
+
+		// ignore ephemeral elements
+		if ephemeral[types.Hash256(se.ID)] {
+			return
+		}
+
 		if spent {
 			spentUTXOs = append(spentUTXOs, se)
 		} else {

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -166,7 +166,7 @@ func applyChainState(tx UpdateTx, address types.Address, cau chain.ApplyUpdate) 
 		utxoValues[types.SiacoinOutputID(se.ID)] = se.SiacoinOutput.Value
 
 		// ignore ephemeral elements
-		if ephemeral[types.Hash256(se.ID)] {
+		if ephemeral[se.ID] {
 			return
 		}
 


### PR DESCRIPTION
Not 100% sure here but I think it's ok to do this. If we ignore all ephemeral elements and thus don't cache their utxo value, I run into the panic on line 194 where we're calculating the total inflow.