### PR TITLE
fix invalid MinerPayouts in testutil.MineBlock

### DIFF
--- a/testutil/network.go
+++ b/testutil/network.go
@@ -1,11 +1,8 @@
 package testutil
 
 import (
-	"time"
-
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils"
 	"go.sia.tech/coreutils/chain"
 )
 
@@ -23,26 +20,4 @@ func Network() (*consensus.Network, types.Block) {
 	n.HardforkV2.AllowHeight = 200 // comfortably above MaturityHeight
 	n.HardforkV2.RequireHeight = 250
 	return n, genesisBlock
-}
-
-// MineBlock mines a block with the given transactions, transaction fees are
-// added to the miner payout.
-func MineBlock(cm *chain.Manager, minerAddress types.Address) types.Block {
-	state := cm.TipState()
-	b := types.Block{
-		ParentID:     state.Index.ID,
-		Timestamp:    types.CurrentTimestamp(),
-		Transactions: cm.PoolTransactions(),
-		MinerPayouts: []types.SiacoinOutput{{Address: minerAddress, Value: state.BlockReward()}},
-	}
-
-	// add txn fees to miner payout
-	for _, txn := range b.Transactions {
-		b.MinerPayouts[0].Value = b.MinerPayouts[0].Value.Add(txn.TotalFees())
-	}
-
-	if !coreutils.FindBlockNonce(state, &b, 5*time.Second) {
-		panic("failed to find nonce")
-	}
-	return b
 }

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -37,7 +37,9 @@ func syncDB(cm *chain.Manager, store wallet.SingleAddressStore) error {
 func mineAndSync(cm *chain.Manager, ws wallet.SingleAddressStore, address types.Address, n uint64) error {
 	// mine n blocks
 	for i := uint64(0); i < n; i++ {
-		if err := cm.AddBlocks([]types.Block{testutil.MineBlock(cm, address)}); err != nil {
+		if block, found := coreutils.MineBlock(cm, address, 5*time.Second); !found {
+			panic("failed to mine block")
+		} else if err := cm.AddBlocks([]types.Block{block}); err != nil {
 			return fmt.Errorf("failed to add blocks: %w", err)
 		}
 	}


### PR DESCRIPTION
Silly little bug in our `MineBlock` implementation where we call `PoolTransactions` twice and thus introduce a race. This eventually results in an error upon validating the block that indicates the miner payout sum doesn't match block reward + fees.