### PR TITLE
Prioritize peers that support V2 RPCs in the sync loop

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 	"time"
 
@@ -529,9 +530,13 @@ func (s *Syncer) syncLoop() error {
 			if p.Synced() {
 				continue
 			}
-			if peers = append(peers, p); len(peers) >= 3 {
-				break
-			}
+			peers = append(peers, p)
+		}
+		sort.Slice(peers, func(i, j int) bool {
+			return peers[i].t.SupportsV2() && !peers[j].t.SupportsV2()
+		})
+		if len(peers) > 3 {
+			peers = peers[:3]
 		}
 		return
 	}


### PR DESCRIPTION
This PR prioritizes peers that support V2 RPCs so we can make use of `MaxSendBlocks` more often, v1 peers use `MaxCatchUpBlocks` which was set to 10 so we sync in batches of only 10 blocks.