### PR TITLE
Remove `Data` from `Event`

### DIFF
--- a/wallet/events.go
+++ b/wallet/events.go
@@ -67,7 +67,6 @@ type (
 		Inflow         types.Currency   `json:"inflow"`
 		Outflow        types.Currency   `json:"outflow"`
 		Type           string           `json:"type"`
-		Data           EventData        `json:"data"`
 		MaturityHeight uint64           `json:"maturityHeight"`
 		Timestamp      time.Time        `json:"timestamp"`
 	}

--- a/wallet/update.go
+++ b/wallet/update.go
@@ -65,7 +65,6 @@ func appliedEvents(cau chain.ApplyUpdate, walletAddress types.Address) (events [
 		ev := Event{
 			ID:        id,
 			Index:     index,
-			Data:      data,
 			Timestamp: block.Timestamp,
 		}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -505,7 +505,6 @@ func (sw *SingleAddressWallet) UnconfirmedTransactions() (annotated []Event, err
 			Inflow:         inflow,
 			Outflow:        outflow,
 			Type:           eventType,
-			Data:           data,
 		}
 		annotated = append(annotated, ev)
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -222,8 +222,6 @@ func TestWallet(t *testing.T) {
 		t.Fatalf("expected 2 transactions, got %v", len(events))
 	} else if events[0].ID != types.Hash256(txn.ID()) {
 		t.Fatalf("expected transaction %v, got %v", txn.ID(), events[1].ID)
-	} else if n := len((events[0].Data.(wallet.EventV1Transaction)).SiacoinOutputs); n != 20 {
-		t.Fatalf("expected 20 outputs, got %v", n)
 	}
 
 	// send all the outputs to the burn address individually
@@ -606,8 +604,6 @@ func TestReorg(t *testing.T) {
 		t.Fatalf("expected 2 transactions, got %v", len(events))
 	} else if events[0].ID != types.Hash256(txn.ID()) {
 		t.Fatalf("expected transaction %v, got %v", txn.ID(), events[1].ID)
-	} else if n := len((events[0].Data.(wallet.EventV1Transaction)).SiacoinOutputs); n != 20 {
-		t.Fatalf("expected 20 outputs, got %v", n)
 	}
 
 	txn2 := types.Transaction{
@@ -870,8 +866,6 @@ func TestWalletV2(t *testing.T) {
 		t.Fatalf("expected 2 transactions, got %v", len(events))
 	} else if events[0].ID != types.Hash256(txn.ID()) {
 		t.Fatalf("expected transaction %v, got %v", txn.ID(), events[1].ID)
-	} else if n := len((events[0].Data.(wallet.EventV1Transaction)).SiacoinOutputs); n != 20 {
-		t.Fatalf("expected 20 outputs, got %v", n)
 	}
 
 	// mine until the v2 require height
@@ -1091,8 +1085,6 @@ func TestReorgV2(t *testing.T) {
 		t.Fatalf("expected 2 transactions, got %v", len(events))
 	} else if events[0].ID != types.Hash256(txn.ID()) {
 		t.Fatalf("expected transaction %v, got %v", txn.ID(), events[1].ID)
-	} else if n := len((events[0].Data.(wallet.EventV2Transaction)).SiacoinOutputs); n != 20 {
-		t.Fatalf("expected 20 outputs, got %v", n)
 	}
 
 	txn2 := types.V2Transaction{


### PR DESCRIPTION
Considering the `SingleAddressWallet` is not meant for an explorer and only tracks events to display the inflow and outflow of siacoins, would it be fine to drop the `Data` from the `Event` @n8maninger ? Seems like the only purpose it has is to initialise the `Event` type right now.

