### PR TITLE
Use context for OnReorg

### DIFF
--- a/chain/manager.go
+++ b/chain/manager.go
@@ -28,6 +28,7 @@ type ApplyUpdate struct {
 	State consensus.State // post-application
 }
 
+// MarshalJSON implements the json.Marshaler interface.
 func (au ApplyUpdate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		ApplyUpdate consensus.ApplyUpdate `json:"applyUpdate"`
@@ -40,6 +41,7 @@ func (au ApplyUpdate) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (au *ApplyUpdate) UnmarshalJSON(b []byte) error {
 	var v struct {
 		ApplyUpdate consensus.ApplyUpdate `json:"applyUpdate"`
@@ -66,6 +68,7 @@ type RevertUpdate struct {
 	State consensus.State // post-reversion, i.e. pre-application
 }
 
+// MarshalJSON implements the json.Marshaler interface.
 func (ru RevertUpdate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		RevertUpdate consensus.RevertUpdate `json:"revertUpdate"`
@@ -78,6 +81,7 @@ func (ru RevertUpdate) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (ru *RevertUpdate) UnmarshalJSON(b []byte) error {
 	var v struct {
 		RevertUpdate consensus.RevertUpdate `json:"revertUpdate"`

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -27,6 +28,35 @@ type ApplyUpdate struct {
 	State consensus.State // post-application
 }
 
+func (au ApplyUpdate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ApplyUpdate consensus.ApplyUpdate `json:"applyUpdate"`
+		Block       types.Block           `json:"block"`
+		State       consensus.State       `json:"state"`
+	}{
+		ApplyUpdate: au.ApplyUpdate,
+		Block:       au.Block,
+		State:       au.State,
+	})
+}
+
+func (au *ApplyUpdate) UnmarshalJSON(b []byte) error {
+	var v struct {
+		ApplyUpdate consensus.ApplyUpdate `json:"applyUpdate"`
+		Block       types.Block           `json:"block"`
+		State       consensus.State       `json:"state"`
+	}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	*au = ApplyUpdate{
+		ApplyUpdate: v.ApplyUpdate,
+		Block:       v.Block,
+		State:       v.State,
+	}
+	return nil
+}
+
 // A RevertUpdate reflects the changes to the blockchain resulting from the
 // removal of a block.
 type RevertUpdate struct {
@@ -34,6 +64,35 @@ type RevertUpdate struct {
 
 	Block types.Block
 	State consensus.State // post-reversion, i.e. pre-application
+}
+
+func (ru RevertUpdate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		RevertUpdate consensus.RevertUpdate `json:"revertUpdate"`
+		Block        types.Block            `json:"block"`
+		State        consensus.State        `json:"state"`
+	}{
+		RevertUpdate: ru.RevertUpdate,
+		Block:        ru.Block,
+		State:        ru.State,
+	})
+}
+
+func (ru *RevertUpdate) UnmarshalJSON(b []byte) error {
+	var v struct {
+		RevertUpdate consensus.RevertUpdate `json:"revertUpdate"`
+		Block        types.Block            `json:"block"`
+		State        consensus.State        `json:"state"`
+	}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	*ru = RevertUpdate{
+		RevertUpdate: v.RevertUpdate,
+		Block:        v.Block,
+		State:        v.State,
+	}
+	return nil
 }
 
 // A Store durably commits Manager-related data to storage. I/O errors must be

--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -49,7 +50,10 @@ func TestManager(t *testing.T) {
 	}
 
 	var reorgs []uint64
-	cm.OnReorg(func(index types.ChainIndex) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cm.OnReorg(ctx, func(index types.ChainIndex) {
 		reorgs = append(reorgs, index.Height)
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.8
 
 require (
 	go.etcd.io/bbolt v1.3.10
-	go.sia.tech/core v0.3.0
+	go.sia.tech/core v0.3.1-0.20240709230149-7292f0e5ecc3
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.25.0
 	lukechampine.com/frand v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.etcd.io/bbolt v1.3.10 h1:+BqfJTcCzTItrop8mq/lbzL8wSGtj94UO/3U31shqG0=
 go.etcd.io/bbolt v1.3.10/go.mod h1:bK3UQLPJZly7IlNmV7uVHJDxfe5aK9Ll93e/74Y9oEQ=
-go.sia.tech/core v0.3.0 h1:PDfAQh9z8PYD+oeVS7rS9SEnTMOZzwwFfAH45yktmko=
-go.sia.tech/core v0.3.0/go.mod h1:BMgT/reXtgv6XbDgUYTCPY7wSMbspDRDs7KMi1vL6Iw=
+go.sia.tech/core v0.3.1-0.20240709230149-7292f0e5ecc3 h1:BdaDN1HAPJxOqz5NWG/UWFeUHG/vEcRRfTlxY3ocEvM=
+go.sia.tech/core v0.3.1-0.20240709230149-7292f0e5ecc3/go.mod h1:BMgT/reXtgv6XbDgUYTCPY7wSMbspDRDs7KMi1vL6Iw=
 go.sia.tech/mux v1.2.0 h1:ofa1Us9mdymBbGMY2XH/lSpY8itFsKIo/Aq8zwe+GHU=
 go.sia.tech/mux v1.2.0/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -44,7 +44,6 @@ type (
 		BestIndex(height uint64) (types.ChainIndex, bool)
 		PoolTransactions() []types.Transaction
 		V2PoolTransactions() []types.V2Transaction
-		OnReorg(func(types.ChainIndex)) func()
 	}
 
 	// A SingleAddressStore stores the state of a single-address wallet.


### PR DESCRIPTION
Updates `OnReorg` to use `context.Context` for managing the lifecycle of the registered functions. Now, the function will be removed when the context is canceled instead of needing to keep track of an extra cancellation function. 

Builds on https://github.com/SiaFoundation/core/pull/180