### PR TITLE
Refactor SingleAddressWallet store

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.8
 
 require (
 	go.etcd.io/bbolt v1.3.10
-	go.sia.tech/core v0.4.1
+	go.sia.tech/core v0.4.2-0.20240723013228-2b1c3d890e25
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.25.0
 	lukechampine.com/frand v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.etcd.io/bbolt v1.3.10 h1:+BqfJTcCzTItrop8mq/lbzL8wSGtj94UO/3U31shqG0=
 go.etcd.io/bbolt v1.3.10/go.mod h1:bK3UQLPJZly7IlNmV7uVHJDxfe5aK9Ll93e/74Y9oEQ=
-go.sia.tech/core v0.4.0 h1:TlbVuiw1nk7wAybSvuZozRixnI4lpmcK0MVIlpJ9ApA=
-go.sia.tech/core v0.4.0/go.mod h1:6dN3J2GDX+f8H2p82MJ7V4BFdnmgoHAiovfmBD/F1Hg=
-go.sia.tech/core v0.4.1 h1:yawkyvr7mHYKWXa8RsHAPriLtJdvDQzqXgq4/hHqjHQ=
-go.sia.tech/core v0.4.1/go.mod h1:6dN3J2GDX+f8H2p82MJ7V4BFdnmgoHAiovfmBD/F1Hg=
+go.sia.tech/core v0.4.2-0.20240723013228-2b1c3d890e25 h1:VEldn/1zMNPdwv8wPimDk6V4D0UXUTU+CufSwQ0Cxug=
+go.sia.tech/core v0.4.2-0.20240723013228-2b1c3d890e25/go.mod h1:6dN3J2GDX+f8H2p82MJ7V4BFdnmgoHAiovfmBD/F1Hg=
 go.sia.tech/mux v1.2.0 h1:ofa1Us9mdymBbGMY2XH/lSpY8itFsKIo/Aq8zwe+GHU=
 go.sia.tech/mux v1.2.0/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -9,7 +9,6 @@ import (
 
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
-	"go.sia.tech/coreutils/chain"
 	"go.uber.org/zap"
 )
 
@@ -63,9 +62,6 @@ type (
 		// WalletEventCount returns the total number of events relevant to the
 		// wallet.
 		WalletEventCount() (uint64, error)
-
-		// UpdateChainState applies and reverts chain updates to the wallet.
-		UpdateChainState([]chain.RevertUpdate, []chain.ApplyUpdate) error
 	}
 
 	// A SingleAddressWallet is a hot wallet that manages the outputs controlled


### PR DESCRIPTION
Removes `UpdateChainState` as a method on the Store interface to make the SingleAddressWallet slightly less opinionated about how its receiving chain updates from the backing store.