### PR TITLE
Wait for goroutines to exit before returning from Close()

### DIFF
--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -48,7 +48,7 @@ func TestSyncer(t *testing.T) {
 		NetAddress: l1.Addr().String(),
 	}, syncer.WithLogger(log.Named("syncer1")))
 	defer s1.Close()
-	go s1.Run()
+	go s1.Run(context.Background())
 
 	s2 := syncer.New(l2, cm2, testutil.NewMemPeerStore(), gateway.Header{
 		GenesisID:  genesis.ID(),
@@ -56,7 +56,7 @@ func TestSyncer(t *testing.T) {
 		NetAddress: l2.Addr().String(),
 	}, syncer.WithLogger(log.Named("syncer2")), syncer.WithSyncInterval(10*time.Millisecond))
 	defer s2.Close()
-	go s2.Run()
+	go s2.Run(context.Background())
 
 	// mine a few blocks on cm1
 	testutil.MineBlocks(t, cm1, types.VoidAddress, 10)


### PR DESCRIPTION
Getting a new panic after #77. Changes `Close()` to block until all goroutines have returned to ensure the chain db stays open until after the syncer has shutdown. 

```
panic: database not open

goroutine 23 [running]:
go.sia.tech/coreutils.(*BoltChainDB).Bucket(0x14000798570?, {0x10255bc00?, 0x9?, 0x9?})
        /Users/n8maninger/go/pkg/mod/go.sia.tech/coreutils@v0.2.2-0.20240801210246-680456645e42/db.go:24 +0xec
go.sia.tech/coreutils/chain.(*DBStore).bucket(...)
        /Users/n8maninger/go/pkg/mod/go.sia.tech/coreutils@v0.2.2-0.20240801210246-680456645e42/chain/db.go:269
go.sia.tech/coreutils/chain.(*DBStore).BestIndex(0x140004c6488, 0x11c92)
        /Users/n8maninger/go/pkg/mod/go.sia.tech/coreutils@v0.2.2-0.20240801210246-680456645e42/chain/db.go:536 +0x84
go.sia.tech/coreutils/chain.(*Manager).History(_)
        /Users/n8maninger/go/pkg/mod/go.sia.tech/coreutils@v0.2.2-0.20240801210246-680456645e42/chain/manager.go:152 +0x18c
go.sia.tech/coreutils/syncer.(*Syncer).syncLoop(0x1400061a360)
        /Users/n8maninger/go/pkg/mod/go.sia.tech/coreutils@v0.2.2-0.20240801210246-680456645e42/syncer/syncer.go:566 +0x1c8
go.sia.tech/coreutils/syncer.(*Syncer).Run.func3()
        /Users/n8maninger/go/pkg/mod/go.sia.tech/coreutils@v0.2.2-0.20240801210246-680456645e42/syncer/syncer.go:636 +0x28
created by go.sia.tech/coreutils/syncer.(*Syncer).Run in goroutine 59
        /Users/n8maninger/go/pkg/mod/go.sia.tech/coreutils@v0.2.2-0.20240801210246-680456645e42/syncer/syncer.go:636 +0x124
exit status 2
```