### PR TITLE
Fix Synced Close

### DIFF
--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -638,6 +638,7 @@ func (s *Syncer) syncLoop(ctx context.Context) error {
 // error occurs, upon which all connections are closed and goroutines are
 // terminated.
 func (s *Syncer) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
 	s.wg.Add(1)
 	defer s.wg.Done()
 	errChan := make(chan error)
@@ -646,6 +647,7 @@ func (s *Syncer) Run(ctx context.Context) error {
 	go func() { errChan <- s.peerLoop(ctx); s.wg.Done() }()
 	go func() { errChan <- s.syncLoop(ctx); s.wg.Done() }()
 	err := <-errChan
+	cancel()
 
 	// when one goroutine exits, shutdown and wait for the others
 	s.l.Close()

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -256,9 +256,6 @@ func (s *Syncer) ban(p *Peer, err error) error {
 }
 
 func (s *Syncer) runPeer(p *Peer) error {
-	s.wg.Add(1)
-	defer s.wg.Done()
-
 	if err := s.pm.AddPeer(p.t.Addr); err != nil {
 		return fmt.Errorf("failed to add peer: %w", err)
 	}
@@ -641,10 +638,13 @@ func (s *Syncer) syncLoop(ctx context.Context) error {
 // error occurs, upon which all connections are closed and goroutines are
 // terminated.
 func (s *Syncer) Run(ctx context.Context) error {
+	s.wg.Add(1)
+	defer s.wg.Done()
 	errChan := make(chan error)
-	go func() { errChan <- s.acceptLoop(ctx) }()
-	go func() { errChan <- s.peerLoop(ctx) }()
-	go func() { errChan <- s.syncLoop(ctx) }()
+	s.wg.Add(3)
+	go func() { errChan <- s.acceptLoop(ctx); s.wg.Done() }()
+	go func() { errChan <- s.peerLoop(ctx); s.wg.Done() }()
+	go func() { errChan <- s.syncLoop(ctx); s.wg.Done() }()
 	err := <-errChan
 
 	// when one goroutine exits, shutdown and wait for the others
@@ -705,7 +705,11 @@ func (s *Syncer) Connect(ctx context.Context, addr string) (*Peer, error) {
 		ConnAddr: conn.RemoteAddr().String(),
 		Inbound:  false,
 	}
-	go s.runPeer(p)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.runPeer(p)
+	}()
 
 	// runPeer does this too, but doing it outside the goroutine prevents a race
 	// where the peer is absent from Peers() despite Connect() having returned


### PR DESCRIPTION
This PR started as the fix to a race condition but when I added the `s.wg.Add` to the goroutines spawned by `Run`, `Close` didn't exit anymore because `Run` deadlocked on `<-errChan`.
That's why I introduced the `WithCancel` to make sure we kill all loops after the first one returns. Apparently closing the listener wasn't good enough to kill all loops.

This also fixes the failing Windows test in https://github.com/SiaFoundation/renterd/pull/1397 since the syncer will no longer use the database after shutdown. 