### PR TITLE
Fix FundTransaction and Redistribute not using V2 Transaction Pool

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -247,6 +247,21 @@ func (sw *SingleAddressWallet) selectUTXOs(amount types.Currency, inputs int, us
 			}
 		}
 	}
+	for _, txn := range sw.cm.V2PoolTransactions() {
+		for _, sci := range txn.SiacoinInputs {
+			tpoolSpent[types.Hash256(sci.Parent.ID)] = true
+			delete(tpoolUtxos, types.Hash256(sci.Parent.ID))
+		}
+		txnID := txn.ID()
+		for i, sco := range txn.SiacoinOutputs {
+			tpoolUtxos[types.Hash256(txn.SiacoinOutputID(txnID, i))] = types.SiacoinElement{
+				StateElement: types.StateElement{
+					ID: types.Hash256(types.SiacoinOutputID(txn.SiacoinOutputID(txnID, i))),
+				},
+				SiacoinOutput: sco,
+			}
+		}
+	}
 
 	// remove immature, locked and spent outputs
 	cs := sw.cm.TipState()
@@ -567,6 +582,11 @@ func (sw *SingleAddressWallet) selectRedistributeUTXOs(bh uint64, outputs int, a
 	for _, txn := range sw.cm.PoolTransactions() {
 		for _, sci := range txn.SiacoinInputs {
 			inPool[types.Hash256(sci.ParentID)] = true
+		}
+	}
+	for _, txn := range sw.cm.V2PoolTransactions() {
+		for _, sci := range txn.SiacoinInputs {
+			inPool[types.Hash256(sci.Parent.ID)] = true
 		}
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -138,19 +138,12 @@ func (sw *SingleAddressWallet) Balance() (balance Balance, err error) {
 			tpoolSpent[types.Hash256(si.Parent.ID)] = true
 			delete(tpoolUtxos, types.Hash256(si.Parent.ID))
 		}
-		txnID := txn.ID()
 		for i, sco := range txn.SiacoinOutputs {
 			if sco.Address != sw.addr {
 				continue
 			}
-
-			outputID := txn.SiacoinOutputID(txnID, i)
-			tpoolUtxos[types.Hash256(outputID)] = types.SiacoinElement{
-				StateElement: types.StateElement{
-					ID: types.Hash256(types.SiacoinOutputID(outputID)),
-				},
-				SiacoinOutput: sco,
-			}
+			sce := txn.EphemeralSiacoinOutput(i)
+			tpoolUtxos[sce.ID] = sce
 		}
 	}
 
@@ -252,14 +245,9 @@ func (sw *SingleAddressWallet) selectUTXOs(amount types.Currency, inputs int, us
 			tpoolSpent[types.Hash256(sci.Parent.ID)] = true
 			delete(tpoolUtxos, types.Hash256(sci.Parent.ID))
 		}
-		txnID := txn.ID()
-		for i, sco := range txn.SiacoinOutputs {
-			tpoolUtxos[types.Hash256(txn.SiacoinOutputID(txnID, i))] = types.SiacoinElement{
-				StateElement: types.StateElement{
-					ID: types.Hash256(types.SiacoinOutputID(txn.SiacoinOutputID(txnID, i))),
-				},
-				SiacoinOutput: sco,
-			}
+		for i := range txn.SiacoinOutputs {
+			sce := txn.EphemeralSiacoinOutput(i)
+			tpoolUtxos[sce.ID] = sce
 		}
 	}
 

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1392,7 +1392,20 @@ func TestFundTransaction(t *testing.T) {
 	}
 
 	// try again using unconfirmed balance, should work
-	_, _, err = w.FundV2Transaction(&txnV2, sendAmt, true)
+	txnV2 = types.V2Transaction{
+		SiacoinOutputs: []types.SiacoinOutput{
+			{
+				Address: w.Address(),
+				Value:   sendAmt,
+			},
+		},
+	}
+	state, toSignV2, err = w.FundV2Transaction(&txnV2, sendAmt, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.SignV2Inputs(state, &txnV2, toSignV2)
+	_, err = cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txnV2})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1355,7 +1355,6 @@ func TestFundTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 	sendAmt := balance.Confirmed
-	fmt.Println("sendAmt", sendAmt)
 
 	txnV2 := types.V2Transaction{
 		SiacoinOutputs: []types.SiacoinOutput{
@@ -1392,7 +1391,7 @@ func TestFundTransaction(t *testing.T) {
 	}
 
 	// try again using unconfirmed balance, should work
-	txnV2 = types.V2Transaction{
+	txnV3 := types.V2Transaction{
 		SiacoinOutputs: []types.SiacoinOutput{
 			{
 				Address: w.Address(),
@@ -1400,12 +1399,12 @@ func TestFundTransaction(t *testing.T) {
 			},
 		},
 	}
-	state, toSignV2, err = w.FundV2Transaction(&txnV2, sendAmt, true)
+	state, toSignV2, err = w.FundV2Transaction(&txnV3, sendAmt, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	w.SignV2Inputs(state, &txnV2, toSignV2)
-	_, err = cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txnV2})
+	w.SignV2Inputs(state, &txnV3, toSignV2)
+	_, err = cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txnV2, txnV3})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1404,7 +1404,7 @@ func TestFundTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 	w.SignV2Inputs(state, &txnV3, toSignV2)
-	_, err = cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txnV2, txnV3})
+	_, err = cm.AddV2PoolTransactions(cm.Tip(), append(cm.V2UnconfirmedParents(txnV3), txnV3))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1318,3 +1318,82 @@ func TestReorgV2(t *testing.T) {
 		t.Fatalf("expected miner payout, got %v", events[0].Type)
 	}
 }
+
+func TestFundTransaction(t *testing.T) {
+	// create wallet store
+	pk := types.GeneratePrivateKey()
+	ws := testutil.NewEphemeralWalletStore(pk)
+
+	// use a network that results in coins mined before and after the v2
+	// hardfork
+	network, genesis := testutil.Network()
+	network.HardforkV2.AllowHeight = 2
+	network.HardforkV2.RequireHeight = 3
+
+	// create chain store
+	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create chain manager and subscribe the wallet
+	cm := chain.NewManager(cs, tipState)
+	// create wallet
+	l := zaptest.NewLogger(t)
+	w, err := wallet.NewSingleAddressWallet(pk, cm, ws, wallet.WithLogger(l.Named("wallet")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	// fund the wallet
+	mineAndSync(t, cm, ws, w, w.Address(), 3)
+	mineAndSync(t, cm, ws, w, types.VoidAddress, 200)
+
+	balance, err := w.Balance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sendAmt := balance.Confirmed
+	fmt.Println("sendAmt", sendAmt)
+
+	txnV2 := types.V2Transaction{
+		SiacoinOutputs: []types.SiacoinOutput{
+			{
+				Address: w.Address(),
+				Value:   sendAmt,
+			},
+		},
+	}
+
+	// Send full confirmed balance to the wallet
+	state, toSignV2, err := w.FundV2Transaction(&txnV2, sendAmt, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.SignV2Inputs(state, &txnV2, toSignV2)
+
+	_, err = cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txnV2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	balance, err = w.Balance()
+	if err != nil {
+		t.Fatal(err)
+	} else if !balance.Unconfirmed.Equals(sendAmt) {
+		t.Fatalf("expected %v unconfirmed balance, got %v", sendAmt, balance.Unconfirmed)
+	}
+
+	// try again, should fail since wallet is empty
+	_, _, err = w.FundV2Transaction(&txnV2, sendAmt, false)
+	if !errors.Is(err, wallet.ErrNotEnoughFunds) {
+		t.Fatal(err)
+	}
+
+	// try again using unconfirmed balance, should work
+	_, _, err = w.FundV2Transaction(&txnV2, sendAmt, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Probably the reason for the funding issue that Luke ran into in `renterd`. Mining a block only bypassed the issue by moving the funds from unconfirmed to confirmed. 