### PR TITLE
Unify wallet types

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -26,6 +26,7 @@ func Network() (*consensus.Network, types.Block) {
 	return n, genesisBlock
 }
 
+// V2Network returns a test network and genesis block with early V2 hardforks
 func V2Network() (*consensus.Network, types.Block) {
 	// use a modified version of Zen
 	n, genesisBlock := chain.TestnetZen()

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -26,6 +26,21 @@ func Network() (*consensus.Network, types.Block) {
 	return n, genesisBlock
 }
 
+func V2Network() (*consensus.Network, types.Block) {
+	// use a modified version of Zen
+	n, genesisBlock := chain.TestnetZen()
+	n.InitialTarget = types.BlockID{0xFF}
+	n.HardforkDevAddr.Height = 1
+	n.HardforkTax.Height = 1
+	n.HardforkStorageProof.Height = 1
+	n.HardforkOak.Height = 1
+	n.HardforkASIC.Height = 1
+	n.HardforkFoundation.Height = 1
+	n.HardforkV2.AllowHeight = 100
+	n.HardforkV2.RequireHeight = 110
+	return n, genesisBlock
+}
+
 // MineBlocks mines n blocks with the reward going to the given address.
 func MineBlocks(t *testing.T, cm *chain.Manager, addr types.Address, n int) {
 	for ; n > 0; n-- {

--- a/testutil/wallet.go
+++ b/testutil/wallet.go
@@ -35,7 +35,10 @@ func (et *ephemeralWalletUpdateTxn) WalletStateElements() (elements []types.Stat
 
 func (et *ephemeralWalletUpdateTxn) UpdateWalletStateElements(elements []types.StateElement) error {
 	for _, se := range elements {
-		utxo := et.store.utxos[types.SiacoinOutputID(se.ID)]
+		utxo, ok := et.store.utxos[types.SiacoinOutputID(se.ID)]
+		if !ok {
+			panic(fmt.Sprintf("siacoin element %q does not exist", se.ID))
+		}
 		utxo.StateElement = se
 		et.store.utxos[types.SiacoinOutputID(se.ID)] = utxo
 	}
@@ -52,7 +55,7 @@ func (et *ephemeralWalletUpdateTxn) WalletApplyIndex(index types.ChainIndex, cre
 	// add siacoin elements
 	for _, se := range created {
 		if _, ok := et.store.utxos[types.SiacoinOutputID(se.ID)]; ok {
-			continue
+			panic("duplicate element")
 		}
 		et.store.utxos[types.SiacoinOutputID(se.ID)] = se
 	}

--- a/testutil/wallet.go
+++ b/testutil/wallet.go
@@ -15,8 +15,6 @@ import (
 // primarily useful for testing or as a reference implementation.
 type (
 	EphemeralWalletStore struct {
-		privateKey types.PrivateKey
-
 		mu     sync.Mutex
 		tip    types.ChainIndex
 		utxos  map[types.SiacoinOutputID]types.SiacoinElement
@@ -144,10 +142,8 @@ func (es *EphemeralWalletStore) Tip() (types.ChainIndex, error) {
 }
 
 // NewEphemeralWalletStore returns a new EphemeralWalletStore.
-func NewEphemeralWalletStore(pk types.PrivateKey) *EphemeralWalletStore {
+func NewEphemeralWalletStore() *EphemeralWalletStore {
 	return &EphemeralWalletStore{
-		privateKey: pk,
-
 		utxos: make(map[types.SiacoinOutputID]types.SiacoinElement),
 	}
 }


### PR DESCRIPTION
The goal of this PR is to unify the wallet types between the four apps. The event types now match `walletd`. The  inflow and outflow fields have been removed and helpers have been added to replace them. 