### PR TITLE
Fix tpool race

### DIFF
--- a/chain/manager.go
+++ b/chain/manager.go
@@ -928,13 +928,23 @@ func (m *Manager) UnconfirmedParents(txn types.Transaction) []types.Transaction 
 	return parents
 }
 
-// V2UnconfirmedParents returns the v2 transactions in the txpool that are referenced
-// by txn.
-func (m *Manager) V2UnconfirmedParents(txn types.V2Transaction) []types.V2Transaction {
+// V2TransactionSet returns the full transaction set and basis necessary for
+// broadcasting a transaction. If the provided basis does not match the current
+// tip the transaction will be updated. The transaction set includes the parents
+// and the transaction itself in an order valid for broadcasting.
+func (m *Manager) V2TransactionSet(basis types.ChainIndex, txn types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.revalidatePool()
 
+	// update the transaction's basis to match tip
+	_, txns, err := m.updateV2TransactionSet(basis, []types.V2Transaction{txn})
+	if err != nil {
+		return types.ChainIndex{}, nil, fmt.Errorf("failed to update transaction set basis: %w", err)
+	}
+	txn = txns[0]
+
+	// get the transaction's parents
 	parentMap := m.computeParentMap()
 	var parents []types.V2Transaction
 	seen := make(map[int]bool)
@@ -975,7 +985,7 @@ func (m *Manager) V2UnconfirmedParents(txn types.V2Transaction) []types.V2Transa
 		j := len(parents) - 1 - i
 		parents[i], parents[j] = parents[j], parents[i]
 	}
-	return parents
+	return m.tipState.Index, append(parents, txn), nil
 }
 
 func (m *Manager) checkDupTxnSet(txns []types.Transaction, v2txns []types.V2Transaction) (types.Hash256, bool) {
@@ -1063,6 +1073,109 @@ func (m *Manager) AddPoolTransactions(txns []types.Transaction) (known bool, err
 	return
 }
 
+// updateV2TransactionSet updates the basis of a transaction set to the current
+// tip. If the basis is already the tip, the transaction set is returned as-is.
+// Any transactions that were confirmed are removed from the set. Any ephemeral
+// state elements that were created by an update are updated.
+//
+// If it is undesirable to modify the transaction set, deep-copy it
+// before calling this method.
+func (m *Manager) updateV2TransactionSet(basis types.ChainIndex, txns []types.V2Transaction) (types.ChainIndex, []types.V2Transaction, error) {
+	if basis == m.tipState.Index {
+		return basis, txns, nil
+	}
+
+	// bring txns up-to-date
+	revert, apply, err := m.reorgPath(basis, m.tipState.Index)
+	if err != nil {
+		return types.ChainIndex{}, nil, fmt.Errorf("couldn't determine reorg path from %v to %v: %w", basis, m.tipState.Index, err)
+	} else if len(revert)+len(apply) > 144 {
+		return types.ChainIndex{}, nil, fmt.Errorf("reorg path from %v to %v is too long (-%v +%v)", basis, m.tipState.Index, len(revert), len(apply))
+	}
+	for _, index := range revert {
+		b, _, cs, ok := blockAndParent(m.store, index.ID)
+		if !ok {
+			return types.ChainIndex{}, nil, fmt.Errorf("missing reverted block at index %v", index)
+		} else if b.V2 == nil {
+			return types.ChainIndex{}, nil, fmt.Errorf("reorg path from %v to %v contains a non-v2 block (%v)", basis, m.tipState.Index, index)
+		}
+		// NOTE: since we are post-hardfork, we don't need a v1 supplement
+		cru := consensus.RevertBlock(cs, b, consensus.V1BlockSupplement{})
+		for i := range txns {
+			if !updateTxnProofs(&txns[i], cru.UpdateElementProof, cs.Elements.NumLeaves) {
+				return types.ChainIndex{}, nil, fmt.Errorf("transaction %v references element that does not exist in our chain", txns[i].ID())
+			}
+		}
+	}
+
+	for _, index := range apply {
+		b, _, cs, ok := blockAndParent(m.store, index.ID)
+		if !ok {
+			return types.ChainIndex{}, nil, fmt.Errorf("missing applied block at index %v", index)
+		} else if b.V2 == nil {
+			return types.ChainIndex{}, nil, fmt.Errorf("reorg path from %v to %v contains a non-v2 block (%v)", basis, m.tipState.Index, index)
+		}
+		// NOTE: since we are post-hardfork, we don't need a v1 supplement or ancestorTimestamp
+		cs, cau := consensus.ApplyBlock(cs, b, consensus.V1BlockSupplement{}, time.Time{})
+
+		// get the transactions that were confirmed in this block
+		confirmedTxns := make(map[types.TransactionID]bool)
+		for _, txn := range b.V2Transactions() {
+			confirmedTxns[txn.ID()] = true
+		}
+		confirmedStateElements := make(map[types.Hash256]types.StateElement)
+		cau.ForEachSiacoinElement(func(sce types.SiacoinElement, created, spent bool) {
+			if created {
+				confirmedStateElements[sce.ID] = sce.StateElement
+			}
+		})
+		cau.ForEachSiafundElement(func(sfe types.SiafundElement, created, spent bool) {
+			if created {
+				confirmedStateElements[sfe.ID] = sfe.StateElement
+			}
+		})
+
+		rem := txns[:0]
+		for i := range txns {
+			if confirmedTxns[txns[i].ID()] {
+				// remove any transactions that were confirmed in this block
+				continue
+			}
+			rem = append(rem, txns[i])
+
+			// update the state elements for any confirmed ephemeral elements
+			for j := range txns[i].SiacoinInputs {
+				if txns[i].SiacoinInputs[j].Parent.LeafIndex != types.UnassignedLeafIndex {
+					continue
+				}
+				se, ok := confirmedStateElements[types.Hash256(txns[i].SiacoinInputs[j].Parent.ID)]
+				if !ok {
+					continue
+				}
+				txns[i].SiacoinInputs[j].Parent.StateElement = se
+			}
+
+			// update the state elements for any confirmed ephemeral elements
+			for j := range txns[i].SiafundInputs {
+				if txns[i].SiafundInputs[j].Parent.LeafIndex != types.UnassignedLeafIndex {
+					continue
+				}
+				se, ok := confirmedStateElements[types.Hash256(txns[i].SiafundInputs[j].Parent.ID)]
+				if !ok {
+					continue
+				}
+				txns[i].SiafundInputs[j].Parent.StateElement = se
+			}
+
+			// NOTE: all elements guaranteed to exist from here on, so no
+			// need to check this return value
+			updateTxnProofs(&rem[len(rem)-1], cau.UpdateElementProof, cs.Elements.NumLeaves)
+		}
+		txns = rem
+	}
+	return m.tipState.Index, txns, nil
+}
+
 // AddV2PoolTransactions validates a transaction set and adds it to the txpool.
 // If any transaction references an element (SiacoinOutput, SiafundOutput, or
 // FileContract) not present in the blockchain, that element must be created by
@@ -1093,44 +1206,10 @@ func (m *Manager) AddV2PoolTransactions(basis types.ChainIndex, txns []types.V2T
 		txns[i] = txns[i].DeepCopy()
 	}
 
-	if basis != m.tipState.Index {
-		// bring txns up-to-date
-		revert, apply, err := m.reorgPath(basis, m.tipState.Index)
-		if err != nil {
-			return false, fmt.Errorf("couldn't determine reorg path from %v to %v: %w", basis, m.tipState.Index, err)
-		} else if len(revert)+len(apply) > 144 {
-			return false, fmt.Errorf("reorg path from %v to %v is too long (-%v +%v)", basis, m.tipState.Index, len(revert), len(apply))
-		}
-		for _, index := range revert {
-			b, _, cs, ok := blockAndParent(m.store, index.ID)
-			if !ok {
-				return false, fmt.Errorf("missing reverted block at index %v", index)
-			} else if b.V2 == nil {
-				return false, m.markBadTxnSet(setID, fmt.Errorf("reorg path from %v to %v contains a non-v2 block (%v)", basis, m.tipState.Index, index))
-			}
-			// NOTE: since we are post-hardfork, we don't need a v1 supplement
-			cru := consensus.RevertBlock(cs, b, consensus.V1BlockSupplement{})
-			for i := range txns {
-				if !updateTxnProofs(&txns[i], cru.UpdateElementProof, cs.Elements.NumLeaves) {
-					return false, m.markBadTxnSet(setID, fmt.Errorf("transaction %v references element that does not exist in our chain", txns[i].ID()))
-				}
-			}
-		}
-		for _, index := range apply {
-			b, _, cs, ok := blockAndParent(m.store, index.ID)
-			if !ok {
-				return false, fmt.Errorf("missing applied block at index %v", index)
-			} else if b.V2 == nil {
-				return false, m.markBadTxnSet(setID, fmt.Errorf("reorg path from %v to %v contains a non-v2 block (%v)", basis, m.tipState.Index, index))
-			}
-			// NOTE: since we are post-hardfork, we don't need a v1 supplement or ancestorTimestamp
-			cs, cau := consensus.ApplyBlock(cs, b, consensus.V1BlockSupplement{}, time.Time{})
-			for i := range txns {
-				// NOTE: all elements guaranteed to exist from here on, so no
-				// need to check this return value
-				updateTxnProofs(&txns[i], cau.UpdateElementProof, cs.Elements.NumLeaves)
-			}
-		}
+	// update the transaction set to the current tip
+	_, txns, err := m.updateV2TransactionSet(basis, txns)
+	if err != nil {
+		return false, m.markBadTxnSet(setID, fmt.Errorf("failed to update set basis: %w", err))
 	}
 
 	// validate as a standalone set

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -941,6 +941,8 @@ func (m *Manager) V2TransactionSet(basis types.ChainIndex, txn types.V2Transacti
 	_, txns, err := m.updateV2TransactionSet(basis, []types.V2Transaction{txn})
 	if err != nil {
 		return types.ChainIndex{}, nil, fmt.Errorf("failed to update transaction set basis: %w", err)
+	} else if len(txns) == 0 {
+		return types.ChainIndex{}, nil, errors.New("no transactions to broadcast")
 	}
 	txn = txns[0]
 

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -1210,6 +1210,8 @@ func (m *Manager) AddV2PoolTransactions(basis types.ChainIndex, txns []types.V2T
 	_, txns, err := m.updateV2TransactionSet(basis, txns)
 	if err != nil {
 		return false, m.markBadTxnSet(setID, fmt.Errorf("failed to update set basis: %w", err))
+	} else if len(txns) == 0 {
+		return true, nil
 	}
 
 	// validate as a standalone set


### PR DESCRIPTION
Fixes a race condition primarily seen when exchanging v2 transaction sets in RHP4. The renter sends the host a transaction set with a particular basis. If the tip changes before the RPC completes and the transaction includes ephemeral outputs, the transaction set will be invalidated and the RPC will fail. This fixes that race by changing the tpool to update the ephemeral state elements and proofs when updating the transaction set basis.