### PR TITLE
Add confirmations field to events

### DIFF
--- a/wallet/events.go
+++ b/wallet/events.go
@@ -69,6 +69,7 @@ type (
 	Event struct {
 		ID             types.Hash256    `json:"id"`
 		Index          types.ChainIndex `json:"index"`
+		Confirmations  uint64           `json:"confirmations"`
 		Type           string           `json:"type"`
 		Data           EventData        `json:"data"`
 		MaturityHeight uint64           `json:"maturityHeight"`


### PR DESCRIPTION
This will reduce a potential race condition for integrators checking the number of confirmations an event has.