### PR TITLE
Add support for block pruning

### DIFF
--- a/.changeset/add_support_for_block_pruning.md
+++ b/.changeset/add_support_for_block_pruning.md
@@ -1,0 +1,17 @@
+---
+default: minor
+---
+
+# Add support for block pruning
+
+#116 by @lukechampine
+
+Been a long time coming. 😅 
+
+The strategy here is quite naive, but I think it will be serviceable. Basically, when we apply a block `N`, we delete block `N-P`. `P` is therefore the "prune target," i.e. the maximum number of blocks you want to store.
+
+In practice, this isn't exhaustive: it only deletes blocks from the best chain. It also won't dramatically shrink the size of an existing database. I think this is acceptable, because pruning is most important during the initial sync, and during the initial sync, you'll only be receiving blocks from one chain at a time. Also, we don't want to make pruning *too* easy; after all, we need a good percentage of nodes to be storing the full chain, so that others can sync to them.
+
+I tested this out locally with a prune target of 1000, and after syncing 400,000 blocks, my `consensus.db` was around 18 GB. This is disappointing; it should be much smaller. With some investigation, I found that the Bolt database was only storing ~5 GB of data (most of which was the accumulator tree, which we can't prune until after v2). I think this is a combination of a) Bolt grows the DB capacity aggressively in response to writes, and b) Bolt never shrinks the DB capacity. So it's possible that we could reduce this number by tweaking our DB batching parameters. Alternatively, we could provide a tool that copies the DB to a new file. Not the most user-friendly, but again, I think I'm okay with that for now.
+
+Depends on https://github.com/SiaFoundation/core/pull/228

--- a/.changeset/add_support_for_block_pruning.md
+++ b/.changeset/add_support_for_block_pruning.md
@@ -4,14 +4,4 @@ default: minor
 
 # Add support for block pruning
 
-#116 by @lukechampine
-
-Been a long time coming. 😅 
-
-The strategy here is quite naive, but I think it will be serviceable. Basically, when we apply a block `N`, we delete block `N-P`. `P` is therefore the "prune target," i.e. the maximum number of blocks you want to store.
-
-In practice, this isn't exhaustive: it only deletes blocks from the best chain. It also won't dramatically shrink the size of an existing database. I think this is acceptable, because pruning is most important during the initial sync, and during the initial sync, you'll only be receiving blocks from one chain at a time. Also, we don't want to make pruning *too* easy; after all, we need a good percentage of nodes to be storing the full chain, so that others can sync to them.
-
-I tested this out locally with a prune target of 1000, and after syncing 400,000 blocks, my `consensus.db` was around 18 GB. This is disappointing; it should be much smaller. With some investigation, I found that the Bolt database was only storing ~5 GB of data (most of which was the accumulator tree, which we can't prune until after v2). I think this is a combination of a) Bolt grows the DB capacity aggressively in response to writes, and b) Bolt never shrinks the DB capacity. So it's possible that we could reduce this number by tweaking our DB batching parameters. Alternatively, we could provide a tool that copies the DB to a new file. Not the most user-friendly, but again, I think I'm okay with that for now.
-
-Depends on https://github.com/SiaFoundation/core/pull/228
+The chain manager can now automatically delete blocks after a configurable number of confirmations. Note that this does not apply retroactively.

--- a/chain/options.go
+++ b/chain/options.go
@@ -11,3 +11,10 @@ func WithLog(l *zap.Logger) ManagerOption {
 		m.log = l
 	}
 }
+
+// WithPruneTarget sets the target number of blocks to store.
+func WithPruneTarget(n uint64) ManagerOption {
+	return func(m *Manager) {
+		m.pruneTarget = n
+	}
+}

--- a/miner.go
+++ b/miner.go
@@ -10,15 +10,17 @@ import (
 
 // FindBlockNonce attempts to find a nonce for b that meets the PoW target.
 func FindBlockNonce(cs consensus.State, b *types.Block, timeout time.Duration) bool {
-	b.Nonce = 0
+	bh := b.Header()
+	bh.Nonce = 0
 	factor := cs.NonceFactor()
 	startBlock := time.Now()
-	for b.ID().CmpWork(cs.ChildTarget) < 0 {
-		b.Nonce += factor
+	for bh.ID().CmpWork(cs.ChildTarget) < 0 {
+		bh.Nonce += factor
 		if time.Since(startBlock) > timeout {
 			return false
 		}
 	}
+	b.Nonce = bh.Nonce
 	return true
 }
 

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -74,7 +74,7 @@ func startTestNode(tb testing.TB, n *consensus.Network, genesis types.Block) (*c
 	}
 	tb.Cleanup(func() { syncerListener.Close() })
 
-	s := syncer.New(syncerListener, cm, testutil.NewMemPeerStore(), gateway.Header{
+	s := syncer.New(syncerListener, cm, testutil.NewEphemeralPeerStore(), gateway.Header{
 		GenesisID:  genesis.ID(),
 		UniqueID:   gateway.GenerateUniqueID(),
 		NetAddress: "localhost:1234",

--- a/syncer/peer.go
+++ b/syncer/peer.go
@@ -182,8 +182,8 @@ func (p *Peer) SendCheckpoint(index types.ChainIndex, timeout time.Duration) (ty
 }
 
 // RelayV2Header relays a v2 block header to the peer.
-func (p *Peer) RelayV2Header(h types.BlockHeader, timeout time.Duration) error {
-	return p.callRPC(&gateway.RPCRelayV2Header{Header: h}, timeout)
+func (p *Peer) RelayV2Header(bh types.BlockHeader, timeout time.Duration) error {
+	return p.callRPC(&gateway.RPCRelayV2Header{Header: bh}, timeout)
 }
 
 // RelayV2BlockOutline relays a v2 block outline to the peer.

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -533,9 +533,9 @@ func (s *Syncer) peerLoop(ctx context.Context) error {
 
 			ctx, cancel := context.WithTimeout(ctx, s.config.ConnectTimeout)
 			if _, err := s.Connect(ctx, p); err != nil {
-				log.Debug("connected to peer", zap.String("peer", p))
-			} else {
 				log.Debug("failed to connect to peer", zap.String("peer", p), zap.Error(err))
+			} else {
+				log.Debug("connected to peer", zap.String("peer", p))
 			}
 			cancel()
 			lastTried[p] = time.Now()
@@ -723,10 +723,12 @@ func (s *Syncer) Connect(ctx context.Context, addr string) (*Peer, error) {
 }
 
 // BroadcastHeader broadcasts a header to all peers.
-func (s *Syncer) BroadcastHeader(h types.BlockHeader) { s.relayHeader(h, nil) }
+func (s *Syncer) BroadcastHeader(bh types.BlockHeader) { s.relayHeader(bh, nil) }
 
 // BroadcastV2Header broadcasts a v2 header to all peers.
-func (s *Syncer) BroadcastV2Header(h types.BlockHeader) { s.relayV2Header(h, nil) }
+func (s *Syncer) BroadcastV2Header(bh types.BlockHeader) {
+	s.relayV2Header(bh, nil)
+}
 
 // BroadcastV2BlockOutline broadcasts a v2 block outline to all peers.
 func (s *Syncer) BroadcastV2BlockOutline(b gateway.V2BlockOutline) { s.relayV2BlockOutline(b, nil) }

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -42,7 +42,7 @@ func TestSyncer(t *testing.T) {
 	}
 	defer l2.Close()
 
-	s1 := syncer.New(l1, cm1, testutil.NewMemPeerStore(), gateway.Header{
+	s1 := syncer.New(l1, cm1, testutil.NewEphemeralPeerStore(), gateway.Header{
 		GenesisID:  genesis.ID(),
 		UniqueID:   gateway.GenerateUniqueID(),
 		NetAddress: l1.Addr().String(),
@@ -50,7 +50,7 @@ func TestSyncer(t *testing.T) {
 	defer s1.Close()
 	go s1.Run(context.Background())
 
-	s2 := syncer.New(l2, cm2, testutil.NewMemPeerStore(), gateway.Header{
+	s2 := syncer.New(l2, cm2, testutil.NewEphemeralPeerStore(), gateway.Header{
 		GenesisID:  genesis.ID(),
 		UniqueID:   gateway.GenerateUniqueID(),
 		NetAddress: l2.Addr().String(),

--- a/testutil/syncer.go
+++ b/testutil/syncer.go
@@ -7,15 +7,15 @@ import (
 	"go.sia.tech/coreutils/syncer"
 )
 
-// A MemPeerStore is an in-memory implementation of a PeerStore.
-type MemPeerStore struct {
+// A EphemeralPeerStore is an in-memory implementation of a PeerStore.
+type EphemeralPeerStore struct {
 	mu    sync.Mutex
 	peers map[string]syncer.PeerInfo
 }
 
 // AddPeer adds a peer to the store. If the peer already exists, nil should
 // be returned.
-func (ps *MemPeerStore) AddPeer(addr string) error {
+func (ps *EphemeralPeerStore) AddPeer(addr string) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	if _, ok := ps.peers[addr]; ok {
@@ -26,7 +26,7 @@ func (ps *MemPeerStore) AddPeer(addr string) error {
 }
 
 // Peers returns the set of known peers.
-func (ps *MemPeerStore) Peers() ([]syncer.PeerInfo, error) {
+func (ps *EphemeralPeerStore) Peers() ([]syncer.PeerInfo, error) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	var peers []syncer.PeerInfo
@@ -38,7 +38,7 @@ func (ps *MemPeerStore) Peers() ([]syncer.PeerInfo, error) {
 
 // PeerInfo returns the metadata for the specified peer or ErrPeerNotFound
 // if the peer wasn't found in the store.
-func (ps *MemPeerStore) PeerInfo(addr string) (syncer.PeerInfo, error) {
+func (ps *EphemeralPeerStore) PeerInfo(addr string) (syncer.PeerInfo, error) {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	p, ok := ps.peers[addr]
@@ -50,7 +50,7 @@ func (ps *MemPeerStore) PeerInfo(addr string) (syncer.PeerInfo, error) {
 
 // UpdatePeerInfo updates the metadata for the specified peer. If the peer
 // is not found, the error should be ErrPeerNotFound.
-func (ps *MemPeerStore) UpdatePeerInfo(addr string, fn func(*syncer.PeerInfo)) error {
+func (ps *EphemeralPeerStore) UpdatePeerInfo(addr string, fn func(*syncer.PeerInfo)) error {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 	p := ps.peers[addr]
@@ -61,18 +61,18 @@ func (ps *MemPeerStore) UpdatePeerInfo(addr string, fn func(*syncer.PeerInfo)) e
 
 // Ban temporarily bans one or more IPs. The addr should either be a single
 // IP with port (e.g. 1.2.3.4:5678) or a CIDR subnet (e.g. 1.2.3.4/16).
-func (ps *MemPeerStore) Ban(addr string, duration time.Duration, reason string) error {
+func (ps *EphemeralPeerStore) Ban(addr string, duration time.Duration, reason string) error {
 	return nil
 }
 
 // Banned returns false
-func (ps *MemPeerStore) Banned(addr string) (bool, error) { return false, nil }
+func (ps *EphemeralPeerStore) Banned(addr string) (bool, error) { return false, nil }
 
-var _ syncer.PeerStore = (*MemPeerStore)(nil)
+var _ syncer.PeerStore = (*EphemeralPeerStore)(nil)
 
-// NewMemPeerStore returns a new MemPeerStore.
-func NewMemPeerStore() *MemPeerStore {
-	return &MemPeerStore{
+// NewEphemeralPeerStore returns a new EphemeralPeerStore.
+func NewEphemeralPeerStore() *EphemeralPeerStore {
+	return &EphemeralPeerStore{
 		peers: make(map[string]syncer.PeerInfo),
 	}
 }


### PR DESCRIPTION
Been a long time coming. 😅 

The strategy here is quite naive, but I think it will be serviceable. Basically, when we apply a block `N`, we delete block `N-P`. `P` is therefore the "prune target," i.e. the maximum number of blocks you want to store.

In practice, this isn't exhaustive: it only deletes blocks from the best chain. It also won't dramatically shrink the size of an existing database. I think this is acceptable, because pruning is most important during the initial sync, and during the initial sync, you'll only be receiving blocks from one chain at a time. Also, we don't want to make pruning *too* easy; after all, we need a good percentage of nodes to be storing the full chain, so that others can sync to them.

I tested this out locally with a prune target of 1000, and after syncing 400,000 blocks, my `consensus.db` was around 18 GB. This is disappointing; it should be much smaller. With some investigation, I found that the Bolt database was only storing ~5 GB of data (most of which was the accumulator tree, which we can't prune until after v2). I think this is a combination of a) Bolt grows the DB capacity aggressively in response to writes, and b) Bolt never shrinks the DB capacity. So it's possible that we could reduce this number by tweaking our DB batching parameters. Alternatively, we could provide a tool that copies the DB to a new file. Not the most user-friendly, but again, I think I'm okay with that for now.

Depends on https://github.com/SiaFoundation/core/pull/228