### PR TITLE
Set Zen v2 activation height

### DIFF
--- a/chain/network.go
+++ b/chain/network.go
@@ -141,8 +141,8 @@ func TestnetZen() (*consensus.Network, types.Block) {
 	n.HardforkFoundation.PrimaryAddress = parseAddr("053b2def3cbdd078c19d62ce2b4f0b1a3c5e0ffbeeff01280efb1f8969b2f5bb4fdc680f0807")
 	n.HardforkFoundation.FailsafeAddress = types.VoidAddress
 
-	n.HardforkV2.AllowHeight = 100000   // TBD
-	n.HardforkV2.RequireHeight = 102000 // ~two weeks later
+	n.HardforkV2.AllowHeight = 112000   // March 1, 2025 @ 7:00:00 UTC
+	n.HardforkV2.RequireHeight = 116380 // 1 month later
 
 	b := types.Block{
 		Timestamp: n.HardforkOak.GenesisTimestamp,


### PR DESCRIPTION
This sets the Zen v2 activation height to March 1, 2025 instead of in ~2 weeks. The primary goal with pushing this back is to not lose our primary production testnet so far from hard fork activation. V2 testing and activation is ongoing on Anagami. This does not change our EoY target for the v2 hard fork release.