### PR TITLE
chain: Handle txpool conflicts properly

### DIFF
--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1879,7 +1879,7 @@ func TestSingleAddressWalletEventTypes(t *testing.T) {
 	})
 }
 
-func TestV2TPoolRace(t *testing.T) {
+func TestV2TxPoolRace(t *testing.T) {
 	// create wallet store
 	pk := types.GeneratePrivateKey()
 	ws := testutil.NewEphemeralWalletStore()
@@ -1946,11 +1946,17 @@ func TestV2TPoolRace(t *testing.T) {
 	// output in the spend transaction invalid unless it is updated.
 	mineAndSync(t, cm, ws, w, types.VoidAddress, 1)
 
-	// broadcast the transaction set including the already confirmed setup
-	// transaction. This seems unnecessary, but it's a fairly common occurrence
-	// when passing transaction sets using unconfirmed outputs between a renter
-	// and host. If the transaction set is not updated correctly, it will fail.
+	// even though the setup transaction has been confirmed, and the spend
+	// transaction is outdated, we can still add them without error: internally,
+	// AddV2PoolTransactions will remove any confirmed transactions, replace any
+	// ephemeral outputs, and update the Merkle proofs of all elements.
 	if _, err := cm.AddV2PoolTransactions(basis, []types.V2Transaction{setupTxn, spendTxn}); err != nil {
 		t.Fatal(err)
+	}
+	// updating the transaction shouldn't change its ID
+	if spendTxn, ok := cm.V2PoolTransaction(spendTxn.ID()); !ok {
+		t.Fatal("expected spend transaction to be in pool")
+	} else if spendTxn.SiacoinInputs[0].Parent.StateElement.LeafIndex == types.UnassignedLeafIndex {
+		t.Fatal("expected ephemeral output to be replaced")
 	}
 }


### PR DESCRIPTION
This PR changes the txpool to reject transactions that conflict with transactions already in the pool. As a result, the set of transactions in the pool should always be mutually valid (albeit possibly too large to fit in one block). Previously, conflicting transactions were allowed to coexist; `siad` does this intentionally, but in `coreutils` it was accidental, leading to surprising and confusing behavior.

Note that there is currently no "replace-by-fee" mechanism for clearing stuck transactions from the pool. This is a somewhat contentious topic, so I'm punting on it for now. Longer term, I expect we'll want at least a basic child-pays-for-parent scheme; see the comment at the top of `revalidatePool`.

Also fixed a bug in `revalidatePool` where low-fee v2 transactions were not removed.