### PR TITLE
Return `V2FileContractRevision` in `RPCLatsetRevision` rather than `V2FileContract`

### DIFF
--- a/rhp/v4/rpc.go
+++ b/rhp/v4/rpc.go
@@ -474,11 +474,11 @@ func RPCFundAccounts(ctx context.Context, t TransportClient, cs consensus.State,
 }
 
 // RPCLatestRevision returns the latest revision of a contract.
-func RPCLatestRevision(ctx context.Context, t TransportClient, contractID types.FileContractID) (types.V2FileContract, error) {
+func RPCLatestRevision(ctx context.Context, t TransportClient, contractID types.FileContractID) (types.V2FileContractRevision, error) {
 	req := rhp4.RPCLatestRevisionRequest{ContractID: contractID}
 	var resp rhp4.RPCLatestRevisionResponse
 	err := callSingleRoundtripRPC(ctx, t, rhp4.RPCLatestRevisionID, &req, &resp)
-	return resp.Contract, err
+	return resp.Revision, err
 }
 
 // RPCSectorRoots returns the sector roots for a contract.

--- a/rhp/v4/server.go
+++ b/rhp/v4/server.go
@@ -463,10 +463,19 @@ func (s *Server) handleRPCLatestRevision(stream net.Conn) error {
 	if err != nil {
 		return fmt.Errorf("failed to lock contract: %w", err)
 	}
+	ci, fce, err := s.contractor.V2FileContractElement(req.ContractID)
+	if err != nil {
+		unlock()
+		return fmt.Errorf("failed to get contract's state element: %w", err)
+	}
 	unlock()
 
 	return rhp4.WriteResponse(stream, &rhp4.RPCLatestRevisionResponse{
-		Contract: state.Revision,
+		ChainIndex: ci,
+		Revision: types.V2FileContractRevision{
+			Parent:   fce,
+			Revision: state.Revision,
+		},
 	})
 }
 


### PR DESCRIPTION
Ran into a little blocker on the rhp4 revision broadcast PR https://github.com/SiaFoundation/renterd/pull/1698

Basically I can't broadcast the revision since the renter doesn't keep track of every revision and the host doesn't return the state element required to broadcast one.

This PR is obviously incomplete without the corresponding `core` update but before opening that as well I wanted to draw attention to the issue.

Essentially this PR changes the `Contract` field on the response to `Revision` and adds a `ChainIndex` as well.