### PR TITLE
fix(rhp4): Return 0 for nonexistent accounts

### DIFF
--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -625,6 +625,7 @@ func TestRPCRenew(t *testing.T) {
 func TestAccounts(t *testing.T) {
 	n, genesis := testutil.V2Network()
 	hostKey, renterKey := types.GeneratePrivateKey(), types.GeneratePrivateKey()
+	account := proto4.Account(renterKey.PublicKey())
 
 	cm, s, w := startTestNode(t, n, genesis)
 
@@ -673,7 +674,13 @@ func TestAccounts(t *testing.T) {
 	revision := formResult.Contract
 
 	cs := cm.TipState()
-	account := proto4.Account(renterKey.PublicKey())
+
+	balance, err := rhp4.RPCAccountBalance(context.Background(), transport, account)
+	if err != nil {
+		t.Fatal(err)
+	} else if !balance.IsZero() {
+		t.Fatal("expected zero balance")
+	}
 
 	accountFundAmount := types.Siacoins(25)
 	fundResult, err := rhp4.RPCFundAccounts(context.Background(), transport, cs, renterKey, revision, []proto4.AccountDeposit{
@@ -713,7 +720,7 @@ func TestAccounts(t *testing.T) {
 	}
 
 	// verify the account balance
-	balance, err := rhp4.RPCAccountBalance(context.Background(), transport, account)
+	balance, err = rhp4.RPCAccountBalance(context.Background(), transport, account)
 	if err != nil {
 		t.Fatal(err)
 	} else if !balance.Equals(accountFundAmount) {

--- a/testutil/host.go
+++ b/testutil/host.go
@@ -210,10 +210,7 @@ func (ec *EphemeralContractor) ReviseV2Contract(contractID types.FileContractID,
 func (ec *EphemeralContractor) AccountBalance(account proto4.Account) (types.Currency, error) {
 	ec.mu.Lock()
 	defer ec.mu.Unlock()
-	balance, ok := ec.accounts[account]
-	if !ok {
-		return types.Currency{}, errors.New("account not found")
-	}
+	balance, _ := ec.accounts[account]
 	return balance, nil
 }
 


### PR DESCRIPTION
Renters expect the host to return 0 balance when an account has not been funded instead of erroring out.