### PR TITLE
Avoid locking when interacting with the database

### DIFF
--- a/.changeset/improve_locking_in_singleaddresswallet_by_avoiding_acquiring_the_mutex_before_a_db_transaction.md
+++ b/.changeset/improve_locking_in_singleaddresswallet_by_avoiding_acquiring_the_mutex_before_a_db_transaction.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Improve locking in SingleAddressWallet by avoiding acquiring the mutex before a db transaction


### PR DESCRIPTION
The issue this solves is the order in which we acquire the `mu` on the wallet and the locking of the database.

Sometimes we start a db transaction which performs its own locking and then acquire `mu` and sometimes we acquire `mu` and then start a db transaction. Which can cause deadlocks for as long as the db transaction hasn't timed out yet.

To fix this the PR refactors the code a bit to make sure we don't hold `mu` when using the database while allowing to acquire `mu` when we are already within a db transaction.

UPDATE: This branch was run against the renterd CI which ran in a loop. It seems to have fixed the issue of `TestConsensusResync` sometimes taking minutes to complete. Instead if consistently finishes in 14-15s. 