### PR TITLE
Use condition rather than polling to wait for closed peers

### DIFF
--- a/.changeset/use_condition_rather_than_polling_to_determine_whether_all_peers_are_closed_in_run.md
+++ b/.changeset/use_condition_rather_than_polling_to_determine_whether_all_peers_are_closed_in_run.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Use condition rather than polling to determine whether all peers are closed in 'Run'


### PR DESCRIPTION
The polling has bitten us a bit when debugging the deadlock since it doesn't show up in a stacktrace. This makes sure that we will be aware of goroutines blocking indefinitely on the condition.