### PR TITLE
Add timeout for incoming RPC

### DIFF
--- a/.changeset/set_2_minute_deadline_for_all_incoming_rpc_in_syncer.md
+++ b/.changeset/set_2_minute_deadline_for_all_incoming_rpc_in_syncer.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Set 2 minute deadline for all incoming RPC in syncer


### PR DESCRIPTION
Adds a new Syncer config option to configure a timeout for incoming RPC requests, defaulting to 2 minutes.

```
goroutine 103739 gp=0xc000104c40 m=nil [sync.Cond.Wait, 4777 minutes]:
runtime.gopark(0xc00204f5c0?, 0x46da3d?, 0x78?, 0xf5?, 0x487170?)
	runtime/proc.go:424 +0xce fp=0xc00204f520 sp=0xc00204f500 pc=0x472d8e
runtime.goparkunlock(...)
	runtime/proc.go:430
sync.runtime_notifyListWait(0xc00457c390, 0x1)
	runtime/sema.go:587 +0x159 fp=0xc00204f570 sp=0xc00204f520 pc=0x4744f9
sync.(*Cond).Wait(0x40?)
	sync/cond.go:71 +0x85 fp=0xc00204f5b0 sp=0xc00204f570 pc=0x483ce5
go.sia.tech/mux/v2.(*Stream).Read(0xc00457c370, {0xc001c93dd8, 0x8, 0xc001c93c88?})
	go.sia.tech/mux@v1.3.0/v2/mux.go:519 +0x1b1 fp=0xc00204f668 sp=0xc00204f5b0 pc=0x81d1d1
go.sia.tech/mux.(*Stream).Read(0x5b9e2f?, {0xc001c93dd8?, 0xc001c93c70?, 0x8?})
	go.sia.tech/mux@v1.3.0/mux.go:165 +0x34 fp=0xc00204f698 sp=0xc00204f668 pc=0x81e7f4
io.(*LimitedReader).Read(0xc001c93dc0, {0xc001c93dd8?, 0x4137e5?, 0x1000000000070?})
	io/io.go:479 +0x43 fp=0xc00204f6c8 sp=0xc00204f698 pc=0x487883
io.ReadAtLeast({0x185f220, 0xc001c93dc0}, {0xc001c93dd8, 0x8, 0x40}, 0x8)
	io/io.go:335 +0x90 fp=0xc00204f710 sp=0xc00204f6c8 pc=0x487170
io.ReadFull(...)
	io/io.go:354
go.sia.tech/core/types.(*Decoder).Read(0xc001c93dc0, {0xc001c93dd8, 0x8, 0x40})
	go.sia.tech/core@v0.9.0/types/encoding.go:183 +0xc9 fp=0xc00204f780 sp=0xc00204f710 pc=0x5a2989
go.sia.tech/core/types.(*Decoder).ReadUint64(...)
	go.sia.tech/core@v0.9.0/types/encoding.go:212
go.sia.tech/core/types.DecodeSlice[...](0xc001c93dc0, 0xc001876320)
	go.sia.tech/core@v0.9.0/types/encoding.go:291 +0x45 fp=0xc00204f7f0 sp=0xc00204f780 pc=0x5b71a5
go.sia.tech/core/gateway.(*RPCRelayTransactionSet).decodeRequest(0xe83440?, 0xc00098d101?)
	go.sia.tech/core@v0.9.0/gateway/encoding.go:252 +0x1f fp=0xc00204f818 sp=0xc00204f7f0 pc=0xaa4b9f
go.sia.tech/core/gateway.Object.decodeRequest-fm(0x7fbef00917b8?)
	<autogenerated>:1 +0x2b fp=0xc00204f838 sp=0xc00204f818 pc=0xaa9deb
go.sia.tech/core/gateway.withV2Decoder({0x1860420, 0xc0018a66b0}, 0x4c4b40, 0xc00204f8a8)
	go.sia.tech/core@v0.9.0/gateway/encoding.go:40 +0x70 fp=0xc00204f860 sp=0xc00204f838 pc=0xaa2f90
go.sia.tech/core/gateway.(*Stream).withDecoder(0xc001876320?, 0xc00204f8c0?, 0x40f305?)
	go.sia.tech/core@v0.9.0/gateway/transport.go:131 +0x4a fp=0xc00204f890 sp=0xc00204f860 pc=0xaa7c2a
go.sia.tech/core/gateway.(*Stream).ReadRequest(0xc0018a66c0, {0x186a970, 0xc001876320})
	go.sia.tech/core@v0.9.0/gateway/transport.go:163 +0x79 fp=0xc00204f8d0 sp=0xc00204f890 pc=0xaa7e59
go.sia.tech/coreutils/syncer.(*Syncer).handleRPC(0xc0003c47e0, {0x52, 0x65, 0x6c, 0x61, 0x79, 0x54, 0x72, 0x61, 0x6e, ...}, ...)
	go.sia.tech/coreutils@v0.10.0/syncer/peer.go:282 +0x2177 fp=0xc002051e30 sp=0xc00204f8d0 pc=0xaad997
go.sia.tech/coreutils/syncer.(*Syncer).runPeer.func3()
	go.sia.tech/coreutils@v0.10.0/syncer/syncer.go:296 +0xc9 fp=0xc002051fe0 sp=0xc002051e30 pc=0xab04c9
runtime.goexit({})
	runtime/asm_amd64.s:1700 +0x1 fp=0xc002051fe8 sp=0xc002051fe0 pc=0x47b201
created by go.sia.tech/coreutils/syncer.(*Syncer).runPeer in goroutine 78238
	go.sia.tech/coreutils@v0.10.0/syncer/syncer.go:290 +0x265
```

