### PR TITLE
wallet: fix wallet Redistribute when outputs is larger than batchsize

### DIFF
--- a/.changeset/fixes_an_issue_where_redistribution_of_wallet_outputs_that_require_more_than_a_single_transaction_would_produce_an_invalid_transaction_set.md
+++ b/.changeset/fixes_an_issue_where_redistribution_of_wallet_outputs_that_require_more_than_a_single_transaction_would_produce_an_invalid_transaction_set.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixes an issue where redistribution of wallet outputs that require more than a single transaction would produce an invalid transaction set

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -500,7 +500,7 @@ func TestWalletRedistribute(t *testing.T) {
 		}
 
 		for i := 0; i < len(txns); i++ {
-			w.SignTransaction(&txns[i], toSign, types.CoveredFields{WholeTransaction: true})
+			w.SignTransaction(&txns[i], toSign[i], types.CoveredFields{WholeTransaction: true})
 		}
 		if _, err := cm.AddPoolTransactions(txns); err != nil {
 			return fmt.Errorf("failed to add transactions to pool: %w", err)
@@ -556,6 +556,17 @@ func TestWalletRedistribute(t *testing.T) {
 		t.Fatalf("expected no transactions, got %v", len(txns))
 	} else if len(toSign) != 0 {
 		t.Fatalf("expected no ids, got %v", len(toSign))
+	}
+
+	// redistribute the wallet into more outputs than the batch size to make
+	// sure the resulting txn set contains more than 1 txn
+	outputs, err := w.SpendableOutputs()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(outputs) >= 11 {
+		t.Fatalf("expected at least 11 outputs, got %v", len(outputs))
+	} else if err := redistribute(types.Siacoins(1e3), 11); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -651,6 +662,17 @@ func TestWalletRedistributeV2(t *testing.T) {
 		t.Fatalf("expected no transactions, got %v", len(txns))
 	} else if len(toSign) != 0 {
 		t.Fatalf("expected no ids, got %v", len(toSign))
+	}
+
+	// redistribute the wallet into more outputs than the batch size to make
+	// sure the resulting txn set contains more than 1 txn
+	outputs, err := w.SpendableOutputs()
+	if err != nil {
+		t.Fatal(err)
+	} else if len(outputs) >= 11 {
+		t.Fatalf("expected at least 11 outputs, got %v", len(outputs))
+	} else if err := redistribute(types.Siacoins(1e3), 11); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This PR extends the tests we have to make sure we verify a redistribution of outputs that requires more than a single transaction.

Atm that doesn't work since multiple batches will reuse the same inputs, creating an invalid txn set in the process. Also signing a set that is the result of a v1 redistribution doesn't work because `SignTransaction` will add redundant signatures to txns.

This PR fixes both of these issues.

Closes https://github.com/SiaFoundation/coreutils/issues/169