### PR TITLE
Consider wallet redistributing successful if at least one txn was created

### DIFF
--- a/.changeset/consider_wallet_redistributing_successful_if_at_least_one_txn_was_created.md
+++ b/.changeset/consider_wallet_redistributing_successful_if_at_least_one_txn_was_created.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixes an issue where wallet redistributing would fail if the number of outputs created were less than requested

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -698,6 +698,10 @@ func (sw *SingleAddressWallet) Redistribute(outputs int, amount, feePerByte type
 		// not enough outputs found
 		fee := feePerInput.Mul64(uint64(len(inputs))).Add(outputFees)
 		if sumOut := SumOutputs(inputs); sumOut.Cmp(want.Add(fee)) < 0 {
+			if len(txns) > 0 {
+				// consider redistributing successful if we could generate at least one txn
+				break
+			}
 			return nil, nil, fmt.Errorf("%w: inputs %v < needed %v + txnFee %v", ErrNotEnoughFunds, sumOut.String(), want.String(), fee.String())
 		}
 
@@ -799,6 +803,10 @@ func (sw *SingleAddressWallet) RedistributeV2(outputs int, amount, feePerByte ty
 		// not enough outputs found
 		fee := feePerInput.Mul64(uint64(len(inputs))).Add(outputFees)
 		if sumOut := SumOutputs(inputs); sumOut.Cmp(want.Add(fee)) < 0 {
+			if len(txns) > 0 {
+				// consider redistributing successful if we could generate at least one txn
+				break
+			}
 			return nil, nil, fmt.Errorf("%w: inputs %v < needed %v + txnFee %v", ErrNotEnoughFunds, sumOut.String(), want.String(), fee.String())
 		}
 


### PR DESCRIPTION
I had this issue before with a custom implementation of the single-address wallet. I solved it back then but it seems to have come back when I switched to the `coreutils` implementation.

Both `Redistribute` and `RedistributeV2` iterate over the available inputs when filling up the batch txn; when no more inputs are available, they stop and return an error.

The thing is that, even if not enough outputs were generated by the function, it should still be a success if at least one txn was generated. Because otherwise, the next wallet maintenance will result in the same error and no outputs will be created.

With the fix, the wallet has at least a chance to spawn the required number of outputs within the next few blocks.