### PR TITLE
lock EphemeralWalletStore for duration of UpdateChainState

### DIFF
--- a/.changeset/fix_data_race_in_ephemeralwalletstore.md
+++ b/.changeset/fix_data_race_in_ephemeralwalletstore.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix data race in EphemeralWalletStore.

--- a/testutil/wallet.go
+++ b/testutil/wallet.go
@@ -91,6 +91,8 @@ func (et *ephemeralWalletUpdateTxn) WalletRevertIndex(index types.ChainIndex, re
 
 // UpdateChainState applies and reverts chain updates to the wallet.
 func (es *EphemeralWalletStore) UpdateChainState(fn func(ux wallet.UpdateTx) error) error {
+	es.mu.Lock()
+	defer es.mu.Unlock()
 	return fn(&ephemeralWalletUpdateTxn{store: es})
 }
 


### PR DESCRIPTION
Ran into a race caused by the transaction on the ephemeral wallet store not being locked. Considering that a txn should be applied atomically in theory, I decided to lock the store for the full duration of the transaction rather than in every transaction function individually
