### PR TITLE
separate quic and siamux transports

### DIFF
--- a/.changeset/add_quic_helpers.md
+++ b/.changeset/add_quic_helpers.md
@@ -1,0 +1,7 @@
+---
+default: major
+---
+
+# Separate RHP4 Transports
+
+The SiaMux and QUIC transports are now separated into `go.sia.tech/rhp/v4/siamux` and `go.sia.tech/rhp/v4/quic` packages. Both packages define a `Dial` and `Serve` helper that can be used to either start a transport server or connect to a host using the transport.

--- a/rhp/v4/quic/quic.go
+++ b/rhp/v4/quic/quic.go
@@ -37,7 +37,6 @@ type (
 	client struct {
 		conn    quic.Connection
 		peerKey types.PublicKey
-		close   chan struct{}
 	}
 
 	// A CertManager provides a valid TLS certificate based on the given ClientHelloInfo.
@@ -114,7 +113,6 @@ func Dial(ctx context.Context, addr string, peerKey types.PublicKey, opts ...Cli
 	return &client{
 		conn:    conn,
 		peerKey: peerKey,
-		close:   make(chan struct{}),
 	}, nil
 }
 

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -18,6 +18,8 @@ import (
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	rhp4 "go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4/quic"
+	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.sia.tech/coreutils/syncer"
 	"go.sia.tech/coreutils/testutil"
 	"go.sia.tech/coreutils/wallet"
@@ -55,7 +57,7 @@ func testRenterHostPairSiaMux(tb testing.TB, hostKey types.PrivateKey, cm rhp4.C
 	rs := rhp4.NewServer(hostKey, cm, s, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	hostAddr := testutil.ServeSiaMux(tb, rs, log.Named("siamux"))
 
-	transport, err := rhp4.DialSiaMux(context.Background(), hostAddr, hostKey.PublicKey())
+	transport, err := siamux.Dial(context.Background(), hostAddr, hostKey.PublicKey())
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -68,7 +70,7 @@ func testRenterHostPairQUIC(tb testing.TB, hostKey types.PrivateKey, cm rhp4.Cha
 	rs := rhp4.NewServer(hostKey, cm, s, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	hostAddr := testutil.ServeQUIC(tb, rs, log.Named("quic"))
 
-	transport, err := rhp4.DialQUIC(context.Background(), hostAddr, hostKey.PublicKey(), rhp4.WithTLSConfig(func(tc *tls.Config) {
+	transport, err := quic.Dial(context.Background(), hostAddr, hostKey.PublicKey(), quic.WithTLSConfig(func(tc *tls.Config) {
 		tc.InsecureSkipVerify = true
 	}))
 	if err != nil {

--- a/rhp/v4/siamux/siamux.go
+++ b/rhp/v4/siamux/siamux.go
@@ -1,4 +1,4 @@
-package rhp
+package siamux
 
 import (
 	"context"
@@ -9,91 +9,92 @@ import (
 
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
+	rhp4 "go.sia.tech/coreutils/rhp/v4"
 	"go.sia.tech/mux"
 	"go.uber.org/zap"
 )
 
 const (
-	// ProtocolTCPSiaMux is the identifier for the SiaMux transport.
-	ProtocolTCPSiaMux chain.Protocol = "siamux"
+	// Protocol is the identifier for the SiaMux transport protocol.
+	Protocol chain.Protocol = "siamux"
 )
 
-// siaMuxClientTransport is a TransportClient that uses the SiaMux multiplexer.
-type siaMuxClientTransport struct {
+// client is a TransportClient that uses the SiaMux multiplexer.
+type client struct {
 	m       *mux.Mux
 	peerKey types.PublicKey
 	close   chan struct{}
 }
 
 // Close implements the [TransportClient] interface.
-func (t *siaMuxClientTransport) Close() error {
+func (c *client) Close() error {
 	select {
-	case <-t.close:
+	case <-c.close:
 	default:
-		close(t.close)
+		close(c.close)
 	}
-	return t.m.Close()
+	return c.m.Close()
 }
 
-func (t *siaMuxClientTransport) FrameSize() int {
+func (c *client) FrameSize() int {
 	return 1440 * 3 // from SiaMux handshake.go
 }
 
-func (t *siaMuxClientTransport) PeerKey() types.PublicKey {
-	return t.peerKey
+func (c *client) PeerKey() types.PublicKey {
+	return c.peerKey
 }
 
 // DialStream implements the [TransportClient] interface.
-func (t *siaMuxClientTransport) DialStream() (net.Conn, error) {
+func (c *client) DialStream() (net.Conn, error) {
 	select {
-	case <-t.close:
+	case <-c.close:
 		return nil, fmt.Errorf("transport closed")
 	default:
 	}
-	s := t.m.DialStream()
+	s := c.m.DialStream()
 	return s, nil
 }
 
-// DialSiaMux creates a new TransportClient using the SiaMux transport.
-func DialSiaMux(ctx context.Context, addr string, peerKey types.PublicKey) (TransportClient, error) {
+// Dial creates a new TransportClient using the SiaMux transport.
+func Dial(ctx context.Context, addr string, peerKey types.PublicKey) (rhp4.TransportClient, error) {
 	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to %q: %w", addr, err)
 	}
 
-	return UpgradeConnSiamux(ctx, conn, peerKey)
+	return Upgrade(ctx, conn, peerKey)
 }
 
-// UpgradeConnSiamux upgrades an existing connection to use the SiaMux transport.
-func UpgradeConnSiamux(ctx context.Context, conn net.Conn, peerKey types.PublicKey) (TransportClient, error) {
+// Upgrade upgrades an existing connection to use the SiaMux transport.
+func Upgrade(ctx context.Context, conn net.Conn, peerKey types.PublicKey) (rhp4.TransportClient, error) {
 	m, err := mux.Dial(conn, peerKey[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to establish siamux connection: %w", err)
 	}
-	return &siaMuxClientTransport{
+	return &client{
 		m:       m,
 		peerKey: peerKey,
 		close:   make(chan struct{}),
 	}, nil
 }
 
-// A muxTransport is a rhp4.Transport that wraps a mux.Mux.
-type muxTransport struct {
+// A transport is a rhp4.Transport that wraps a mux.Mux.
+type transport struct {
 	m *mux.Mux
 }
 
 // Close implements the rhp4.Transport interface.
-func (mt *muxTransport) Close() error {
-	return mt.m.Close()
+func (t *transport) Close() error {
+	return t.m.Close()
 }
 
 // AcceptStream implements the rhp4.Transport interface.
-func (mt *muxTransport) AcceptStream() (net.Conn, error) {
-	return mt.m.AcceptStream()
+func (t *transport) AcceptStream() (net.Conn, error) {
+	return t.m.AcceptStream()
 }
 
-// ServeSiaMux serves RHP4 connections on l using the provided server and logger.
-func ServeSiaMux(l net.Listener, s *Server, log *zap.Logger) {
+// Serve serves RHP4 connections on the listener l using the SiaMux transport.
+func Serve(l net.Listener, s *rhp4.Server, log *zap.Logger) {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
@@ -113,7 +114,7 @@ func ServeSiaMux(l net.Listener, s *Server, log *zap.Logger) {
 				}
 				return
 			}
-			s.Serve(&muxTransport{m}, log)
+			s.Serve(&transport{m}, log)
 		}()
 	}
 }

--- a/testutil/host.go
+++ b/testutil/host.go
@@ -6,21 +6,46 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 	"net"
 	"sync"
 	"testing"
 
-	"github.com/quic-go/quic-go"
-	"github.com/quic-go/quic-go/http3"
 	"go.sia.tech/core/consensus"
 	proto4 "go.sia.tech/core/rhp/v4"
 	"go.sia.tech/core/types"
 	"go.sia.tech/coreutils/chain"
 	rhp4 "go.sia.tech/coreutils/rhp/v4"
+	"go.sia.tech/coreutils/rhp/v4/quic"
+	"go.sia.tech/coreutils/rhp/v4/siamux"
 	"go.uber.org/zap"
 	"lukechampine.com/frand"
 )
+
+// An EphemeralCertManager is an in-memory minimal rhp4.CertManager for testing.
+// Calls to GetCertificate will return a new self-signed certificate each time.
+type EphemeralCertManager struct{}
+
+func (ec *EphemeralCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	key, err := rsa.GenerateKey(frand.Reader, 2048)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate key: %w", err)
+	}
+	template := x509.Certificate{SerialNumber: big.NewInt(1)}
+	certDER, err := x509.CreateCertificate(frand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cert: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tls cert: %w", err)
+	}
+	return &cert, nil
+}
 
 // An EphemeralSectorStore is an in-memory minimal rhp4.SectorStore for testing.
 type EphemeralSectorStore struct {
@@ -380,44 +405,30 @@ func ServeSiaMux(tb testing.TB, s *rhp4.Server, log *zap.Logger) string {
 	}
 	tb.Cleanup(func() { l.Close() })
 
-	go rhp4.ServeSiaMux(l, s, log)
+	go siamux.Serve(l, s, log)
 	return l.Addr().String()
 }
 
 // ServeQUIC starts a RHP4 host listening on a random port and returns the address.
 func ServeQUIC(tb testing.TB, s *rhp4.Server, log *zap.Logger) string {
-	key, err := rsa.GenerateKey(frand.Reader, 2048)
+	udpAddr, err := net.ResolveUDPAddr("udp", "localhost:0")
 	if err != nil {
-		tb.Fatal("failed to generate key:", err)
-	}
-	template := x509.Certificate{SerialNumber: big.NewInt(1)}
-	certDER, err := x509.CreateCertificate(frand.Reader, &template, &template, &key.PublicKey, key)
-	if err != nil {
-		tb.Fatal("failed to create certificate:", err)
-	}
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
-	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-
-	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		tb.Fatal("failed to create tls key pair:", err)
+		tb.Fatal(err)
 	}
 
-	l, err := quic.ListenAddr("[::]:4848", &tls.Config{
-		Certificates:       []tls.Certificate{tlsCert},
-		NextProtos:         []string{http3.NextProtoH3, rhp4.TLSNextProtoRHP4},
-		InsecureSkipVerify: true,
-	},
-		&quic.Config{
-			EnableDatagrams: true,
-		})
+	conn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { conn.Close() })
+
+	l, err := quic.Listen(conn, &EphemeralCertManager{})
 	if err != nil {
 		tb.Fatal(err)
 	}
 	tb.Cleanup(func() { l.Close() })
-
-	go rhp4.ServeQUIC(l, s, log)
-	return "localhost:4848"
+	go quic.Serve(l, s, log)
+	return conn.LocalAddr().String()
 }
 
 // NewEphemeralSettingsReporter creates an EphemeralSettingsReporter for testing.

--- a/testutil/host.go
+++ b/testutil/host.go
@@ -27,6 +27,7 @@ import (
 // Calls to GetCertificate will return a new self-signed certificate each time.
 type EphemeralCertManager struct{}
 
+// GetCertificate returns a new self-signed certificate each time it is called.
 func (ec *EphemeralCertManager) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	key, err := rsa.GenerateKey(frand.Reader, 2048)
 	if err != nil {


### PR DESCRIPTION
Separates the `siamux` and QUIC transports into `go.sia.tech/rhp/v4/siamux` and `go.sia.tech/rhp/v4/quic` packages. Both packages define a `Dial` and `Serve` helper that can be used to either start a transport server or connect to a host using the transport.

This simplifies the naming and provides slightly better semantics.