### PR TITLE
Increase default max streams for QUIC

### DIFF
--- a/.changeset/increase_default_max_streams_from_100_to_1000_for_quic_transport.md
+++ b/.changeset/increase_default_max_streams_from_100_to_1000_for_quic_transport.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Increase default max streams from 100 to 1000 for QUIC transport

--- a/rhp/v4/quic/quic.go
+++ b/rhp/v4/quic/quic.go
@@ -185,7 +185,8 @@ func Listen(conn net.PacketConn, certs CertManager) (*quic.Listener, error) {
 		GetCertificate: certs.GetCertificate,
 		NextProtos:     []string{TLSNextProtoRHP4, http3.NextProtoH3},
 	}, &quic.Config{
-		EnableDatagrams: true,
+		EnableDatagrams:    true,
+		MaxIncomingStreams: 1000,
 	})
 }
 


### PR DESCRIPTION
There's a slight race in the QUIC protocol when counting open streams that causes our short-lived streams to consistently cause "too many open streams" errors.