### PR TITLE
allow v1 basis updates

### DIFF
--- a/chain/manager.go
+++ b/chain/manager.go
@@ -1107,6 +1107,8 @@ func (m *Manager) updateV2TransactionProofs(txns []types.V2Transaction, from, to
 		b, bs, cs, ok := blockAndParent(m.store, index.ID)
 		if !ok {
 			return nil, fmt.Errorf("missing reverted block at index %v", index)
+		} else if bs == nil {
+			bs = new(consensus.V1BlockSupplement)
 		}
 		cru := consensus.RevertBlock(cs, b, *bs)
 		for i := range txns {
@@ -1120,8 +1122,11 @@ func (m *Manager) updateV2TransactionProofs(txns []types.V2Transaction, from, to
 		b, bs, cs, ok := blockAndParent(m.store, index.ID)
 		if !ok {
 			return nil, fmt.Errorf("missing applied block at index %v", index)
+		} else if bs == nil {
+			bs = new(consensus.V1BlockSupplement)
 		}
-		cs, cau := consensus.ApplyBlock(cs, b, *bs, time.Time{})
+		ancestorTimestamp, _ := m.store.AncestorTimestamp(b.ParentID)
+		cs, cau := consensus.ApplyBlock(cs, b, *bs, ancestorTimestamp)
 
 		// get the transactions that were confirmed in this block
 		confirmedTxns := make(map[types.TransactionID]bool)


### PR DESCRIPTION
We have run into a problem on Zen when the renter and host are not completely synced. There are still miners mining the occasional V1 block causing contract formation to fail. 

@lukechampine since we're storing all the block supplements regardless, is this a safe change to make? After the require height, b.V2 will always be non-nil. Feel free to take over this PR if it is not to your liking.