### PR TITLE
fix: Add context to siamux Upgrade

### DIFF
--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -856,7 +856,7 @@ func TestSiamuxDialUpgradeTimeout(t *testing.T) {
 		return err != nil && (strings.Contains(err.Error(), "use of closed network connection") || strings.Contains(err.Error(), "operation was canceled"))
 	}
 
-	sr := &blockingSettingsReporter{blockChan: make(chan struct{})}
+	sr := testutil.NewEphemeralSettingsReporter()
 	hk := types.GeneratePrivateKey()
 	rs := rhp4.NewServer(hk, cm, s, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	hostAddr := testutil.ServeSiaMux(t, rs, zap.NewNop())


### PR DESCRIPTION
Noticed that the `Upgrade` function is still timing out in `renterd` so I checked and noticed that it didn't impose a deadline. 
So to unbreak the interface change I added the `ctx` back and moved the timeout safeguard from `Dial` to `Upgrade`