### PR TITLE
DB migration

### DIFF
--- a/.changeset/db_migration.md
+++ b/.changeset/db_migration.md
@@ -1,0 +1,7 @@
+---
+default: CHANGE_TYPE
+---
+
+# DB migration
+
+This adds a generic `MigrateDB` function for updating consensus databases, and a v1->v2 migration that recomputes the full element tree, which fixes Zen.

--- a/.changeset/db_migration.md
+++ b/.changeset/db_migration.md
@@ -1,5 +1,5 @@
 ---
-default: CHANGE_TYPE
+default: major
 ---
 
 # DB migration

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -129,7 +129,7 @@ func TestV2Attestations(t *testing.T) {
 	}
 
 	t.Run("arbitrary data", func(t *testing.T) {
-		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -164,7 +164,7 @@ func TestV2Attestations(t *testing.T) {
 	})
 
 	t.Run("arbitrary data + attestation + no change output", func(t *testing.T) {
-		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -213,7 +213,7 @@ func TestV2Attestations(t *testing.T) {
 	})
 
 	t.Run("arbitrary data + attestation", func(t *testing.T) {
-		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -257,7 +257,7 @@ func TestV2Attestations(t *testing.T) {
 	})
 
 	t.Run("arbitrary data + attestation + change output", func(t *testing.T) {
-		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/chain/db.go
+++ b/chain/db.go
@@ -474,7 +474,7 @@ func (db *DBStore) revertState(prev consensus.State) {
 
 func (db *DBStore) applyElements(cau consensus.ApplyUpdate) {
 	cau.ForEachTreeNode(func(row, col uint64, h types.Hash256) {
-		db.bucket(bTree).put(db.treeKey(row, col), h)
+		db.bucket(bTree).putRaw(db.treeKey(row, col), h[:])
 	})
 
 	for _, sced := range cau.SiacoinElementDiffs() {
@@ -566,7 +566,7 @@ func (db *DBStore) revertElements(cru consensus.RevertUpdate) {
 	}
 
 	cru.ForEachTreeNode(func(row, col uint64, h types.Hash256) {
-		db.bucket(bTree).put(db.treeKey(row, col), h)
+		db.bucket(bTree).putRaw(db.treeKey(row, col), h[:])
 	})
 
 	// NOTE: Although the element tree has shrunk, we do not need to explicitly
@@ -777,9 +777,8 @@ func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block) (_ *DBSto
 		n:  n,
 	}
 
-	// if the db is empty, initialize it; otherwise, check that the genesis
-	// block is correct
-	if dbGenesis, ok := dbs.BestIndex(0); !ok {
+	// if the db is empty, initialize it
+	if version := dbs.bucket(bVersion).getRaw(bVersion); len(version) != 1 {
 		for _, bucket := range [][]byte{
 			bVersion,
 			bMainChain,
@@ -794,7 +793,7 @@ func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block) (_ *DBSto
 				panic(err)
 			}
 		}
-		dbs.bucket(bVersion).putRaw(bVersion, []byte{1})
+		dbs.bucket(bVersion).putRaw(bVersion, []byte{2})
 
 		// store genesis state and apply genesis block to it
 		genesisState := n.GenesisState()
@@ -807,7 +806,12 @@ func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block) (_ *DBSto
 		if err := dbs.Flush(); err != nil {
 			return nil, consensus.State{}, err
 		}
-	} else if dbGenesis.ID != genesisBlock.ID() {
+	} else if version[0] != 2 {
+		return nil, consensus.State{}, errors.New("incompatible version; please migrate the database")
+	}
+
+	// check that we have the correct genesis block for this network
+	if dbGenesis, ok := dbs.BestIndex(0); !ok || dbGenesis.ID != genesisBlock.ID() {
 		// try to detect network so we can provide a more helpful error message
 		_, mainnetGenesis := Mainnet()
 		_, zenGenesis := TestnetZen()

--- a/chain/db_test.go
+++ b/chain/db_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestGetEmptyBlockID(t *testing.T) {
 	n, genesisBlock := testutil.V2Network()
-	store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -24,7 +24,7 @@ func TestGetEmptyBlockID(t *testing.T) {
 
 func TestExpiringFileContracts(t *testing.T) {
 	n, genesisBlock := chain.TestnetZen()
-	store, cs, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	store, cs, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -25,7 +25,7 @@ func TestManager(t *testing.T) {
 
 	n.InitialTarget = types.BlockID{0xFF}
 
-	store, tipState, err := NewDBStore(NewMemDB(), n, genesisBlock)
+	store, tipState, err := NewDBStore(NewMemDB(), n, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,7 +119,7 @@ func TestTxPool(t *testing.T) {
 	}
 	genesisBlock.Transactions = []types.Transaction{giftTxn}
 
-	store, tipState, err := NewDBStore(NewMemDB(), n, genesisBlock)
+	store, tipState, err := NewDBStore(NewMemDB(), n, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestUpdateV2TransactionSet(t *testing.T) {
 	}
 
 	// initialize chain manager and mine a mix of v1 and v2 blocks
-	store, genesisState, err := NewDBStore(NewMemDB(), n, genesisBlock)
+	store, genesisState, err := NewDBStore(NewMemDB(), n, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -17,6 +17,11 @@ type MigrationLogger interface {
 	SetProgress(percentage float64)
 }
 
+type noopLogger struct{}
+
+func (noopLogger) Printf(string, ...any) {}
+func (noopLogger) SetProgress(float64)   {}
+
 // MigrateDB upgrades the database to the latest version.
 func MigrateDB(db DB, n *consensus.Network, l MigrationLogger) error {
 	if db.Bucket(bVersion) == nil {

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -1,0 +1,97 @@
+package chain
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+)
+
+// A MigrationLogger logs the progress of a database migration.
+type MigrationLogger interface {
+	Printf(format string, v ...any)
+	SetProgress(percentage float64)
+}
+
+// MigrateDB upgrades the database to the latest version.
+func MigrateDB(db DB, n *consensus.Network, l MigrationLogger) error {
+	if db.Bucket(bVersion) == nil {
+		return nil // nothing to migrate
+	}
+	dbs := &DBStore{
+		db: db,
+		n:  n,
+	}
+
+	version := dbs.bucket(bVersion).getRaw(bVersion)
+	if version == nil {
+		version = []byte{1}
+	}
+	switch version[0] {
+	case 1:
+		l.Printf("Migrating database from version 1 to 2")
+		l.Printf("Computing new element tree")
+		cs := n.GenesisState()
+		v1Blocks := min(dbs.getHeight(), n.HardforkV2.RequireHeight)
+		seen := make(map[[2]uint64]types.Hash256)
+		var tree [][2][]byte
+		flush := func() error {
+			sort.Slice(tree, func(i, j int) bool {
+				return bytes.Compare(tree[i][0], tree[j][0]) < 0
+			})
+			bucket := dbs.bucket(bTree)
+			for _, kv := range tree {
+				bucket.putRaw(kv[0], kv[1])
+			}
+			clear(seen)
+			tree = tree[:0]
+			return db.Flush()
+		}
+		lastPrint := time.Now()
+		for height := range v1Blocks {
+			index, ok0 := dbs.BestIndex(height)
+			_, b, bs, ok1 := dbs.getBlock(index.ID)
+			ancestorTimestamp, ok2 := dbs.AncestorTimestamp(b.ParentID)
+			if !ok0 || !ok1 || !ok2 {
+				return errors.New("database is corrupt")
+			} else if b == nil || bs == nil {
+				return errors.New("missing block needed for migration")
+			}
+			var cau consensus.ApplyUpdate
+			cs, cau = consensus.ApplyBlock(cs, *b, *bs, ancestorTimestamp)
+			cau.ForEachTreeNode(func(row, col uint64, h types.Hash256) {
+				if _, ok := seen[[2]uint64{row, col}]; !ok {
+					seen[[2]uint64{row, col}] = h
+					tree = append(tree, [2][]byte{dbs.treeKey(row, col), h[:]})
+				}
+			})
+			const maxTreeSize = 100e6 // use up to 100 MB of memory
+			if len(tree)*(16+32) >= maxTreeSize {
+				if err := flush(); err != nil {
+					return err
+				}
+			}
+			if time.Since(lastPrint) > 100*time.Millisecond {
+				l.SetProgress(99.9 * float64(height) / float64(v1Blocks))
+				lastPrint = time.Now()
+			}
+		}
+		// final flush
+		if err := flush(); err != nil {
+			return err
+		}
+		dbs.bucket(bVersion).putRaw(bVersion, []byte{2})
+		dbs.Flush()
+		l.SetProgress(100)
+		fallthrough
+	case 2:
+		// up-to-date
+		return nil
+	default:
+		return fmt.Errorf("unrecognized version (%d)", version[0])
+	}
+}

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -22,16 +22,7 @@ type noopLogger struct{}
 func (noopLogger) Printf(string, ...any) {}
 func (noopLogger) SetProgress(float64)   {}
 
-// MigrateDB upgrades the database to the latest version.
-func MigrateDB(db DB, n *consensus.Network, l MigrationLogger) error {
-	if db.Bucket(bVersion) == nil {
-		return nil // nothing to migrate
-	}
-	dbs := &DBStore{
-		db: db,
-		n:  n,
-	}
-
+func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 	version := dbs.bucket(bVersion).getRaw(bVersion)
 	if version == nil {
 		version = []byte{1}
@@ -54,7 +45,7 @@ func MigrateDB(db DB, n *consensus.Network, l MigrationLogger) error {
 			}
 			clear(seen)
 			tree = tree[:0]
-			return db.Flush()
+			return dbs.Flush()
 		}
 		lastPrint := time.Now()
 		for height := range v1Blocks {

--- a/miner_test.go
+++ b/miner_test.go
@@ -23,7 +23,7 @@ func TestMiner(t *testing.T) {
 		},
 	}}
 
-	store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestV2MineBlocks(t *testing.T) {
 		},
 	}}
 
-	store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock)
+	store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -94,7 +94,7 @@ func testRenterHostPairQUIC(tb testing.TB, hostKey types.PrivateKey, cm rhp4.Cha
 }
 
 func startTestNode(tb testing.TB, n *consensus.Network, genesis types.Block) (*chain.Manager, *syncer.Syncer, *wallet.SingleAddressWallet) {
-	db, tipstate, err := chain.NewDBStore(chain.NewMemDB(), n, genesis)
+	db, tipstate, err := chain.NewDBStore(chain.NewMemDB(), n, genesis, nil)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -19,7 +19,7 @@ import (
 
 func newTestSyncer(t testing.TB, name string, log *zap.Logger) (*syncer.Syncer, *chain.Manager) {
 	n, genesis := testutil.Network()
-	store, tipState1, err := chain.NewDBStore(chain.NewMemDB(), n, genesis)
+	store, tipState1, err := chain.NewDBStore(chain.NewMemDB(), n, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -213,7 +213,7 @@ func TestWallet(t *testing.T) {
 
 	// create chain store
 	network, genesis := testutil.Network()
-	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +370,7 @@ func TestWalletUnconfirmed(t *testing.T) {
 
 	// create chain store
 	network, genesis := testutil.Network()
-	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -472,7 +472,7 @@ func TestWalletRedistribute(t *testing.T) {
 
 	// create chain store
 	network, genesis := testutil.Network()
-	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -578,7 +578,7 @@ func TestWalletRedistributeV2(t *testing.T) {
 	// create chain store
 	network, genesis := testutil.Network()
 	network.HardforkV2.AllowHeight = 1 // allow V2 transactions from the start
-	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,7 +683,7 @@ func TestReorg(t *testing.T) {
 
 	// create chain store
 	network, genesis := testutil.Network()
-	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -897,7 +897,7 @@ func TestWalletV2(t *testing.T) {
 
 	// create chain store
 	network, genesis := testutil.Network()
-	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1074,7 +1074,7 @@ func TestReorgV2(t *testing.T) {
 
 	// create chain store
 	network, genesis := testutil.V2Network()
-	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1325,7 +1325,7 @@ func TestFundTransaction(t *testing.T) {
 	network.HardforkV2.RequireHeight = 3
 
 	// create chain store
-	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, tipState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1425,7 +1425,7 @@ func TestSingleAddressWalletEventTypes(t *testing.T) {
 	network, genesisBlock := testutil.V2Network()
 	// raise the require height to test v1 events
 	network.HardforkV2.RequireHeight = 100
-	store, genesisState, err := chain.NewDBStore(bdb, network, genesisBlock)
+	store, genesisState, err := chain.NewDBStore(bdb, network, genesisBlock, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1812,7 +1812,7 @@ func TestV2TxPoolRace(t *testing.T) {
 
 	// create chain store
 	network, genesis := testutil.V2Network()
-	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis)
+	cs, genesisState, err := chain.NewDBStore(chain.NewMemDB(), network, genesis, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds a generic `MigrateDB` function for updating consensus databases, and a v1->v2 migration that recomputes the full element tree. I haven't run a full mainnet migration yet, but migrating the first 200k blocks took ~12 minutes, so likely around 30 minutes for the entire chain.