### PR TITLE
Return up to `maxBlocks` updates, not up to `maxBlocks+1`

### DIFF
--- a/.changeset/return_up_to_maxblocks_updates_not_up_to_maxblocks_plus_1.md
+++ b/.changeset/return_up_to_maxblocks_updates_not_up_to_maxblocks_plus_1.md
@@ -1,0 +1,5 @@
+---
+ default: patch
+ ---
+ 
+ # Return up to maxBlocks updates, not up to maxBlocks+1

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -427,7 +427,7 @@ func (m *Manager) UpdatesSince(index types.ChainIndex, maxBlocks int) (rus []Rev
 		return bi.ID == index.ID || index == types.ChainIndex{}
 	}
 
-	for index != m.tipState.Index && len(rus)+len(aus) <= maxBlocks {
+	for index != m.tipState.Index && len(rus)+len(aus) < maxBlocks {
 		// revert until we are on the best chain, then apply
 		if !onBestChain(index) {
 			b, bs, cs, ok := blockAndParent(m.store, index.ID)


### PR DESCRIPTION
This is not a big deal, but if you request like 100 updates per batch, you would normally expect the last synced index to grow like `100, 200, 300, ...` and not like `101, 202, 303, ...`.