### PR TITLE
More aggressive migration

### DIFF
--- a/.changeset/more_aggressive_migration.md
+++ b/.changeset/more_aggressive_migration.md
@@ -1,0 +1,13 @@
+---
+default: patch
+---
+
+# More aggressive migration
+
+#210 by @lukechampine
+
+Previous piecemeal attempts at migration produced further discrepancies in the DB. Here we avoid this by taking a scorched-earth approach, nuking basically everything in the DB and resyncing from ourselves. Since sidechains cannot easily be fixed the same way, they are simply deleted. This produces a final state equivalent to resyncing from a good peer.
+
+I have tested this with both Zen and Erravimus consensus.dbs, and it appears to successfully repair them to a valid state. (I reached block 113487 on Zen, and 3311 on Erravimus.) I suggest we deploy this to Erravimus, confirm that we can continue mining there, then deploy to Zen miners. Note that existing Zen blocks above 113487 will (eventually) be reorged.
+
+Performance-wise, there is room for improvement here. The old migration code achieved significant speedups by caching DB writes in memory and sorting them before flushing. I am tempted to apply a similar strategy to the `DBStore` itself, in a more generic fashion -- but this is slightly risky and not critical, so if I do explore it, it'll be on a different branch.

--- a/chain/db.go
+++ b/chain/db.go
@@ -794,7 +794,7 @@ func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block, logger Mi
 				panic(err)
 			}
 		}
-		dbs.bucket(bVersion).putRaw(bVersion, []byte{2})
+		dbs.bucket(bVersion).putRaw(bVersion, []byte{3})
 
 		// store genesis state and apply genesis block to it
 		genesisState := n.GenesisState()
@@ -807,7 +807,7 @@ func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block, logger Mi
 		if err := dbs.Flush(); err != nil {
 			return nil, consensus.State{}, err
 		}
-	} else if version[0] != 2 {
+	} else if version[0] != 3 {
 		if logger == nil {
 			logger = noopLogger{}
 		}

--- a/chain/db.go
+++ b/chain/db.go
@@ -825,7 +825,7 @@ func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block, logger Mi
 		if logger == nil {
 			logger = noopLogger{}
 		}
-		if err := migrateDB(dbs, n, genesisBlock, logger); err != nil {
+		if err := migrateDB(dbs, n, logger); err != nil {
 			return nil, consensus.State{}, fmt.Errorf("failed to migrate database: %w", err)
 		}
 	}

--- a/chain/db.go
+++ b/chain/db.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"iter"
 	"math/bits"
+	"sort"
 	"time"
 
 	"go.sia.tech/core/consensus"
@@ -149,7 +150,9 @@ func (db *MemDB) delete(bucket string, key []byte) error {
 
 // Bucket implements DB.
 func (db *MemDB) Bucket(name []byte) DBBucket {
-	if db.buckets[string(name)] == nil && db.puts[string(name)] == nil && db.dels[string(name)] == nil {
+	if db.buckets[string(name)] == nil &&
+		db.puts[string(name)] == nil &&
+		db.dels[string(name)] == nil {
 		return nil
 	}
 	return memBucket{string(name), db}
@@ -194,6 +197,151 @@ func NewMemDB() *MemDB {
 		buckets: make(map[string]map[string][]byte),
 		puts:    make(map[string]map[string][]byte),
 		dels:    make(map[string]map[string]struct{}),
+	}
+}
+
+type cacheBucket struct {
+	mb memBucket
+	db DBBucket
+}
+
+func (b cacheBucket) Get(key []byte) []byte {
+	if val := b.mb.Get(key); val != nil {
+		return val
+	}
+	return b.db.Get(key)
+}
+
+func (b cacheBucket) Put(key, value []byte) error {
+	err := b.mb.Put(key, value)
+	return err
+}
+
+func (b cacheBucket) Delete(key []byte) error {
+	return b.mb.Delete(key)
+}
+
+func (b cacheBucket) Iter() iter.Seq2[[]byte, []byte] {
+	return func(yield func([]byte, []byte) bool) {
+		for k, v := range b.mb.Iter() {
+			if !yield(k, v) {
+				return
+			}
+		}
+		for k, v := range b.db.Iter() {
+			_, put := b.mb.db.puts[b.mb.name][string(k)]
+			_, deleted := b.mb.db.dels[b.mb.name][string(k)]
+			if put || deleted {
+				continue
+			} else if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+// A CacheDB caches DB writes in memory and sorts them before flushing to the
+// underlying DB. This can greatly improve performance for certain databases.
+type CacheDB struct {
+	mem *MemDB
+	db  DB
+	kvs map[string][][2][]byte
+}
+
+// Bucket implements DB.
+func (db *CacheDB) Bucket(name []byte) DBBucket {
+	b := db.db.Bucket(name)
+	if b == nil {
+		return nil
+	} else if db.mem.Bucket(name) == nil {
+		db.mem.CreateBucket(name)
+	}
+	return cacheBucket{memBucket{string(name), db.mem}, b}
+}
+
+// CreateBucket implements DB.
+func (db *CacheDB) CreateBucket(name []byte) (DBBucket, error) {
+	if _, err := db.db.CreateBucket(name); err != nil {
+		return nil, err
+	}
+	return db.mem.CreateBucket(name)
+}
+
+// Flush implements DB.
+func (db *CacheDB) Flush() error {
+	// puts
+	for name, puts := range db.mem.puts {
+		bucket := db.kvs[name]
+		for key, val := range puts {
+			if _, ok := db.mem.dels[name][key]; ok {
+				continue
+			}
+			bucket = append(bucket, [2][]byte{[]byte(key), val})
+		}
+		db.kvs[name] = bucket
+	}
+	for bucket, kvs := range db.kvs {
+		bucket := db.db.Bucket([]byte(bucket))
+		sort.Slice(kvs, func(i, j int) bool {
+			return bytes.Compare(kvs[i][0], kvs[j][0]) < 0
+		})
+		for _, kv := range kvs {
+			bucket.Put(kv[0], kv[1])
+		}
+	}
+	// remove references
+	for name := range db.kvs {
+		clear(db.kvs[name])
+		db.kvs[name] = db.kvs[name][:0]
+	}
+
+	// dels
+	for name, dels := range db.mem.dels {
+		bucket := db.kvs[name]
+		for key := range dels {
+			bucket = append(bucket, [2][]byte{[]byte(key), nil})
+		}
+		db.kvs[name] = bucket
+	}
+	for name, kvs := range db.kvs {
+		bucket := db.db.Bucket([]byte(name))
+		sort.Slice(kvs, func(i, j int) bool {
+			return bytes.Compare(kvs[i][0], kvs[j][0]) < 0
+		})
+		for _, kv := range kvs {
+			bucket.Delete(kv[0])
+		}
+	}
+	for name := range db.kvs {
+		clear(db.kvs[name])
+		db.kvs[name] = db.kvs[name][:0]
+	}
+
+	// clear MemDB
+	for _, bucket := range db.mem.buckets {
+		clear(bucket)
+	}
+	for _, bucket := range db.mem.puts {
+		clear(bucket)
+	}
+	for _, bucket := range db.mem.dels {
+		clear(bucket)
+	}
+	return db.db.Flush()
+}
+
+// Cancel implements DB.
+func (db *CacheDB) Cancel() {
+	db.mem.Cancel()
+	db.db.Cancel()
+}
+
+// NewCacheDB returns a new CacheDB that wraps the given DB.
+func NewCacheDB(db DB) DB {
+	return &CacheDB{
+		mem: NewMemDB(),
+		db:  db,
+		kvs: make(map[string][][2][]byte),
 	}
 }
 
@@ -245,6 +393,7 @@ func (b *dbBucket) put(key []byte, v types.EncoderTo) {
 
 func (b *dbBucket) delete(key []byte) {
 	check(b.b.Delete(key))
+	b.db.unflushed += len(key)
 }
 
 var (
@@ -729,8 +878,8 @@ func (db *DBStore) PruneBlock(id types.BlockID) {
 func (db *DBStore) shouldFlush() bool {
 	// NOTE: these values were chosen empirically and should constitute a
 	// sensible default; if necessary, we can make them configurable
-	const flushSizeThreshold = 20e6
-	const flushDurationThreshold = 1000 * time.Millisecond
+	const flushSizeThreshold = 100e6
+	const flushDurationThreshold = 5 * time.Second
 	return db.unflushed >= flushSizeThreshold || time.Since(db.lastFlush) >= flushDurationThreshold
 }
 
@@ -765,9 +914,10 @@ func (db *DBStore) Flush() error {
 	if db.unflushed == 0 {
 		return nil
 	}
+	err := db.db.Flush()
 	db.unflushed = 0
 	db.lastFlush = time.Now()
-	return db.db.Flush()
+	return err
 }
 
 // NewDBStore creates a new DBStore using the provided database. The tip state

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -66,18 +66,39 @@ func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 			dbs.bucket(bStates).delete(id[:])
 		}
 		l.Printf("Removing block supplement data")
+		dels := 0
+		flushDeletes := func() error {
+			if dels++; dels%10000 == 0 {
+				return dbs.Flush()
+			}
+			return nil
+		}
 		for id := range dbs.db.Bucket(bFileContractElements).Iter() {
 			dbs.bucket(bFileContractElements).delete(id)
+			if err := flushDeletes(); err != nil {
+				return err
+			}
 		}
 		for id := range dbs.db.Bucket(bSiacoinElements).Iter() {
 			dbs.bucket(bSiacoinElements).delete(id)
+			if err := flushDeletes(); err != nil {
+				return err
+			}
 		}
 		for id := range dbs.db.Bucket(bSiafundElements).Iter() {
 			dbs.bucket(bSiafundElements).delete(id)
+			if err := flushDeletes(); err != nil {
+				return err
+			}
 		}
 		l.Printf("Removing tree data")
 		for k := range dbs.db.Bucket(bTree).Iter() {
 			dbs.bucket(bTree).delete(k)
+			if dels++; dels%10000 == 0 {
+				if err := dbs.Flush(); err != nil {
+					return err
+				}
+			}
 		}
 
 		l.Printf("Recomputing main chain")
@@ -97,10 +118,7 @@ func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 					if index, ok := dbs.BestIndex(height); ok {
 						dbs.bucket(bBlocks).delete(index.ID[:])
 						dbs.bucket(bStates).delete(index.ID[:])
-					}
-					// deletes need to be flushed too
-					if height%500 == 0 {
-						if err := dbs.Flush(); err != nil {
+						if err := flushDeletes(); err != nil {
 							return err
 						}
 					}

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -98,6 +98,12 @@ func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 						dbs.bucket(bBlocks).delete(index.ID[:])
 						dbs.bucket(bStates).delete(index.ID[:])
 					}
+					// deletes need to be flushed too
+					if height%500 == 0 {
+						if err := dbs.Flush(); err != nil {
+							return err
+						}
+					}
 				}
 				break
 			}

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -1,10 +1,8 @@
 package chain
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"go.sia.tech/core/consensus"
@@ -48,49 +46,74 @@ func NewZapMigrationLogger(log *zap.Logger) MigrationLogger {
 	return &zapMigrationLogger{logger: log.Named("chainMigration")}
 }
 
-func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
+func migrateDB(dbs *DBStore, n *consensus.Network, genesisBlock types.Block, l MigrationLogger) error {
 	version := dbs.bucket(bVersion).getRaw(bVersion)
 	switch version[0] {
-	case 1:
-		l.Printf("Migrating database from version 1 to 2")
-		l.Printf("Computing new element tree")
-		cs := n.GenesisState()
-		v1Blocks := min(dbs.getHeight(), n.HardforkV2.RequireHeight)
-		seen := make(map[[2]uint64]types.Hash256)
-		var tree [][2][]byte
-		flush := func() error {
-			sort.Slice(tree, func(i, j int) bool {
-				return bytes.Compare(tree[i][0], tree[j][0]) < 0
-			})
-			bucket := dbs.bucket(bTree)
-			for _, kv := range tree {
-				bucket.putRaw(kv[0], kv[1])
-			}
-			clear(seen)
-			tree = tree[:0]
-			return dbs.Flush()
+	case 1, 2, 3:
+		l.Printf("Removing sidechain blocks")
+		toDelete := make(map[types.BlockID]bool)
+		for id := range dbs.db.Bucket(bBlocks).Iter() {
+			toDelete[(types.BlockID)(id)] = true
 		}
+		for _, id := range dbs.db.Bucket(bMainChain).Iter() {
+			if len(id) == 32 {
+				delete(toDelete, (types.BlockID)(id))
+			}
+		}
+		for id := range toDelete {
+			dbs.bucket(bBlocks).delete(id[:])
+			dbs.bucket(bStates).delete(id[:])
+		}
+		l.Printf("Removing block supplement data")
+		for id := range dbs.db.Bucket(bFileContractElements).Iter() {
+			dbs.bucket(bFileContractElements).delete(id)
+		}
+		for id := range dbs.db.Bucket(bSiacoinElements).Iter() {
+			dbs.bucket(bSiacoinElements).delete(id)
+		}
+		for id := range dbs.db.Bucket(bSiafundElements).Iter() {
+			dbs.bucket(bSiafundElements).delete(id)
+		}
+		l.Printf("Removing tree data")
+		for k := range dbs.db.Bucket(bTree).Iter() {
+			dbs.bucket(bTree).delete(k)
+		}
+
+		l.Printf("Recomputing main chain")
+		v1Blocks := min(dbs.getHeight(), n.HardforkV2.RequireHeight)
+		bs := consensus.V1BlockSupplement{Transactions: make([]consensus.V1TransactionSupplement, len(genesisBlock.Transactions))}
+		cs, cau := consensus.ApplyBlock(n.GenesisState(), genesisBlock, bs, time.Time{})
+		dbs.putBlock(genesisBlock.Header(), &genesisBlock, &bs)
+		dbs.putState(cs)
+		dbs.ApplyBlock(cs, cau)
 		lastPrint := time.Now()
 		for height := range v1Blocks {
 			index, ok0 := dbs.BestIndex(height)
-			_, b, bs, ok1 := dbs.getBlock(index.ID)
+			_, b, _, ok1 := dbs.getBlock(index.ID)
 			ancestorTimestamp, ok2 := dbs.AncestorTimestamp(b.ParentID)
 			if !ok0 || !ok1 || !ok2 {
 				return errors.New("database is corrupt")
-			} else if b == nil || bs == nil {
+			} else if b == nil {
 				return errors.New("missing block needed for migration")
 			}
-			var cau consensus.ApplyUpdate
-			cs, cau = consensus.ApplyBlock(cs, *b, *bs, ancestorTimestamp)
-			cau.ForEachTreeNode(func(row, col uint64, h types.Hash256) {
-				if _, ok := seen[[2]uint64{row, col}]; !ok {
-					seen[[2]uint64{row, col}] = h
-					tree = append(tree, [2][]byte{dbs.treeKey(row, col), h[:]})
+			bs := dbs.SupplementTipBlock(*b)
+			dbs.putBlock(b.Header(), b, &bs)
+			if err := consensus.ValidateBlock(cs, *b, bs); err != nil && cs.Index.Height > 0 {
+				l.Printf("Block %v is invalid, removing it and all subsequent blocks", index)
+				for ; height < v1Blocks; height++ {
+					if index, ok := dbs.BestIndex(height); ok {
+						dbs.bucket(bBlocks).delete(index.ID[:])
+						dbs.bucket(bStates).delete(index.ID[:])
+					}
 				}
-			})
-			const maxTreeSize = 100e6 // use up to 100 MB of memory
-			if len(tree)*(16+32) >= maxTreeSize {
-				if err := flush(); err != nil {
+				break
+			}
+			var cau consensus.ApplyUpdate
+			cs, cau = consensus.ApplyBlock(cs, *b, bs, ancestorTimestamp)
+			dbs.putState(cs)
+			dbs.ApplyBlock(cs, cau)
+			if dbs.shouldFlush() {
+				if err := dbs.Flush(); err != nil {
 					return err
 				}
 			}
@@ -99,65 +122,13 @@ func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 				lastPrint = time.Now()
 			}
 		}
-		// final flush
-		if err := flush(); err != nil {
+		dbs.bucket(bVersion).putRaw(bVersion, []byte{4})
+		if err := dbs.Flush(); err != nil {
 			return err
 		}
-		dbs.bucket(bVersion).putRaw(bVersion, []byte{2})
-		dbs.Flush()
 		l.SetProgress(100)
 		fallthrough
-	case 2:
-		l.Printf("Migrating database from version 2 to 3")
-		l.Printf("Recomputing expiring file contracts")
-		cs := n.GenesisState()
-		v1Blocks := min(dbs.getHeight(), n.HardforkV2.RequireHeight)
-		lastPrint := time.Now()
-		seen := make(map[uint64]bool)
-		for height := range v1Blocks {
-			index, ok0 := dbs.BestIndex(height)
-			_, b, bs, ok1 := dbs.getBlock(index.ID)
-			ancestorTimestamp, ok2 := dbs.AncestorTimestamp(b.ParentID)
-			if !ok0 || !ok1 || !ok2 {
-				return errors.New("database is corrupt")
-			} else if b == nil || bs == nil {
-				return errors.New("missing block needed for migration")
-			}
-			var cau consensus.ApplyUpdate
-			cs, cau = consensus.ApplyBlock(cs, *b, *bs, ancestorTimestamp)
-
-			for _, fced := range cau.FileContractElementDiffs() {
-				fce := &fced.FileContractElement
-				// if this is the first time we've seen this expiration height,
-				// clear the existing contents
-				if windowEnd := fce.FileContract.WindowEnd; !seen[windowEnd] {
-					dbs.bucket(bFileContractElements).putRaw(dbs.encHeight(windowEnd), nil)
-					seen[windowEnd] = true
-				}
-				if fced.Created && fced.Resolved {
-					continue
-				} else if fced.Resolved {
-					dbs.deleteFileContractExpiration(fce.ID, fce.FileContract.WindowEnd)
-				} else if fced.Revision != nil {
-					if fced.Revision.WindowEnd != fce.FileContract.WindowEnd {
-						dbs.deleteFileContractExpiration(fce.ID, fce.FileContract.WindowEnd)
-						dbs.putFileContractExpiration(fce.ID, fced.Revision.WindowEnd, true)
-					}
-				} else {
-					dbs.putFileContractExpiration(fce.ID, fce.FileContract.WindowEnd, true)
-				}
-			}
-
-			if time.Since(lastPrint) > 100*time.Millisecond {
-				l.SetProgress(99.9 * float64(height) / float64(v1Blocks))
-				lastPrint = time.Now()
-			}
-		}
-		dbs.bucket(bVersion).putRaw(bVersion, []byte{3})
-		dbs.Flush()
-		l.SetProgress(100)
-		fallthrough
-	case 3:
+	case 4:
 		// up-to-date
 		return nil
 	default:

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -41,7 +41,8 @@ func (zl *zapMigrationLogger) SetProgress(percentage float64) {
 	zl.lastProgressReport = time.Now()
 }
 
-// NewZapMigrationLogger creates a new MigrationLogger that uses zap for logging progress.
+// NewZapMigrationLogger creates a new MigrationLogger that uses zap for logging
+// progress.
 func NewZapMigrationLogger(log *zap.Logger) MigrationLogger {
 	return &zapMigrationLogger{logger: log.Named("chainMigration")}
 }
@@ -82,7 +83,6 @@ func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 		l.Printf("Recomputing main chain")
 		v1Blocks := min(dbs.getHeight(), n.HardforkV2.RequireHeight) + 1
 		cs := n.GenesisState()
-		lastPrint := time.Now()
 		for height := range v1Blocks {
 			index, _ := dbs.BestIndex(height)
 			_, b, _, _ := dbs.getBlock(index.ID)
@@ -117,10 +117,7 @@ func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 					return err
 				}
 			}
-			if time.Since(lastPrint) > 100*time.Millisecond {
-				l.SetProgress(99.9 * float64(height) / float64(v1Blocks))
-				lastPrint = time.Now()
-			}
+			l.SetProgress(99.9 * float64(height) / float64(v1Blocks))
 		}
 		dbs.bucket(bVersion).putRaw(bVersion, []byte{4})
 		if err := dbs.Flush(); err != nil {

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -122,6 +122,9 @@ func migrateDB(dbs *DBStore, n *consensus.Network, l MigrationLogger) error {
 			}
 			l.SetProgress(99.9 * float64(height) / float64(v1Blocks))
 		}
+		if err := dbs.Flush(); err != nil {
+			return err
+		}
 		dbs.bucket(bVersion).putRaw(bVersion, []byte{4})
 		if err := dbs.Flush(); err != nil {
 			return err


### PR DESCRIPTION
Previous piecemeal attempts at migration produced further discrepancies in the DB. Here we avoid this by taking a scorched-earth approach, nuking basically everything in the DB and resyncing from ourselves. Since sidechains cannot easily be fixed the same way, they are simply deleted. This produces a final state equivalent to resyncing from a good peer.

I have tested this with both Zen and Erravimus consensus.dbs, and it appears to successfully repair them to a valid state. (I reached block 113487 on Zen, and 3311 on Erravimus.) I suggest we deploy this to Erravimus, confirm that we can continue mining there, then deploy to Zen miners. Note that existing Zen blocks above 113487 will (eventually) be reorged.

Performance-wise, there is room for improvement here. The old migration code achieved significant speedups by caching DB writes in memory and sorting them before flushing. I am tempted to apply a similar strategy to the `DBStore` itself, in a more generic fashion -- but this is slightly risky and not critical, so if I do explore it, it'll be on a different branch.