### PR TITLE
Pass MissedHostValue to Validate

### DIFF
--- a/.changeset/pass_missedhostvalue_to_validate_when_refreshing_contracts_using_rhp4.md
+++ b/.changeset/pass_missedhostvalue_to_validate_when_refreshing_contracts_using_rhp4.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Pass MissedHostValue to Validate when refreshing contracts using RHP4.

--- a/rhp/v4/server.go
+++ b/rhp/v4/server.go
@@ -767,11 +767,7 @@ func (s *Server) handleRPCRefreshContract(stream net.Conn) error {
 
 	// validate the request
 	settings := s.settings.RHP4Settings()
-	existingCollateral, underflow := state.Revision.TotalCollateral.SubWithUnderflow(state.Revision.MissedHostValue)
-	if underflow {
-		return errorBadRequest("contract total collateral less than missed host value")
-	}
-	if err := req.Validate(s.hostKey.PublicKey(), existingCollateral, state.Revision.TotalCollateral, existing.RenterOutput.Value, state.Revision.ExpirationHeight, settings.MaxCollateral); err != nil {
+	if err := req.Validate(s.hostKey.PublicKey(), state.Revision.MissedHostValue, state.Revision.TotalCollateral, existing.RenterOutput.Value, state.Revision.ExpirationHeight, settings.MaxCollateral); err != nil {
 		return rhp4.NewRPCError(rhp4.ErrorCodeBadRequest, err.Error())
 	}
 


### PR DESCRIPTION
I think we made a mistake here. `Validate` expects the existing unallocated collateral and the unallocated collateral should be the `MissedHostValue` rather than `TotalCollateral-MissedHostValue`. After all, when we pay with a contract, that's the field we subtract from.