### PR TITLE
Add error to relay transaction set

### DIFF
--- a/.changeset/return_error_when_transaction_set_relay_fails.md
+++ b/.changeset/return_error_when_transaction_set_relay_fails.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Return error when transaction set relay fails

--- a/rhp/v4/server.go
+++ b/rhp/v4/server.go
@@ -56,7 +56,7 @@ type (
 	// A Syncer broadcasts transactions to its peers.
 	Syncer interface {
 		// BroadcastV2TransactionSet broadcasts a transaction set to the network.
-		BroadcastV2TransactionSet(types.ChainIndex, []types.V2Transaction)
+		BroadcastV2TransactionSet(types.ChainIndex, []types.V2Transaction) error
 	}
 
 	// A Wallet manages Siacoins and funds transactions.
@@ -728,10 +728,10 @@ func (s *Server) handleRPCFormContract(stream net.Conn) error {
 	}, usage)
 	if err != nil {
 		return fmt.Errorf("failed to add contract: %w", err)
+	} else if err := s.syncer.BroadcastV2TransactionSet(basis, formationSet); err != nil {
+		return fmt.Errorf("failed to broadcast transaction set: %w", err)
 	}
-	// broadcast the finalized contract formation set
 	broadcast = true // set broadcast so the UTXOs will not be released if the renter happens to disconnect before receiving the last response
-	s.syncer.BroadcastV2TransactionSet(basis, formationSet)
 
 	// send the finalized transaction set to the renter
 	return rhp4.WriteResponse(stream, &rhp4.RPCFormContractThirdResponse{
@@ -908,10 +908,10 @@ func (s *Server) handleRPCRefreshContract(stream net.Conn) error {
 	}, usage)
 	if err != nil {
 		return fmt.Errorf("failed to add contract: %w", err)
+	} else if err := s.syncer.BroadcastV2TransactionSet(basis, renewalSet); err != nil {
+		return fmt.Errorf("failed to broadcast transaction set: %w", err)
 	}
-
 	broadcast = true // set broadcast so the UTXOs will not be released if the renter happens to disconnect before receiving the last response
-	s.syncer.BroadcastV2TransactionSet(basis, renewalSet)
 
 	// send the finalized transaction set to the renter
 	return rhp4.WriteResponse(stream, &rhp4.RPCRefreshContractThirdResponse{
@@ -1086,10 +1086,10 @@ func (s *Server) handleRPCRenewContract(stream net.Conn) error {
 	}, usage)
 	if err != nil {
 		return fmt.Errorf("failed to add contract: %w", err)
+	} else if err := s.syncer.BroadcastV2TransactionSet(basis, renewalSet); err != nil {
+		return fmt.Errorf("failed to broadcast transaction set: %w", err)
 	}
-
 	broadcast = true // set broadcast so the UTXOs will not be released if the renter happens to disconnect before receiving the last response
-	s.syncer.BroadcastV2TransactionSet(basis, renewalSet)
 
 	// send the finalized transaction set to the renter
 	return rhp4.WriteResponse(stream, &rhp4.RPCRenewContractThirdResponse{

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -17,6 +17,8 @@ import (
 	"lukechampine.com/frand"
 )
 
+// ErrNoPeers is returned when there are no peers available to relay
+// to
 var ErrNoPeers = errors.New("no peers available")
 
 // A ChainManager manages blockchain state.

--- a/syncer/syncer.go
+++ b/syncer/syncer.go
@@ -403,7 +403,7 @@ func (s *Syncer) withV2Peers(origin *Peer, fn func(p *Peer) error) error {
 }
 
 func (s *Syncer) relayHeader(h types.BlockHeader, origin *Peer) error {
-	return s.withPeers(origin, func(p *Peer) error { p.RelayHeader(h, s.config.RelayHeaderTimeout); return nil })
+	return s.withPeers(origin, func(p *Peer) error { return p.RelayHeader(h, s.config.RelayHeaderTimeout) })
 }
 
 func (s *Syncer) relayTransactionSet(txns []types.Transaction, origin *Peer) error {
@@ -414,11 +414,11 @@ func (s *Syncer) relayTransactionSet(txns []types.Transaction, origin *Peer) err
 }
 
 func (s *Syncer) relayV2Header(bh types.BlockHeader, origin *Peer) error {
-	return s.withV2Peers(origin, func(p *Peer) error { p.RelayV2Header(bh, s.config.RelayHeaderTimeout); return nil })
+	return s.withV2Peers(origin, func(p *Peer) error { return p.RelayV2Header(bh, s.config.RelayHeaderTimeout) })
 }
 
 func (s *Syncer) relayV2BlockOutline(pb gateway.V2BlockOutline, origin *Peer) error {
-	return s.withV2Peers(origin, func(p *Peer) error { p.RelayV2BlockOutline(pb, s.config.RelayBlockOutlineTimeout); return nil })
+	return s.withV2Peers(origin, func(p *Peer) error { return p.RelayV2BlockOutline(pb, s.config.RelayBlockOutlineTimeout) })
 }
 
 func (s *Syncer) relayV2TransactionSet(index types.ChainIndex, txns []types.V2Transaction, origin *Peer) error {


### PR DESCRIPTION
This adds an error to the syncer methods and changes them to block until at least one relay returns successful. This won't guarantee that the transaction set is actually accepted by any peers, but it makes it more likely that at least one other peer received it.

Also noticed that we ban peers that relay transaction sets with no transactions, while it's a fair practice I added a check to prevent "good" clients from being banned since we rarely check length before calling broadcast.

This may help with debugging random broadcast issues (https://github.com/SiaFoundation/hostd/issues/646)