### PR TITLE
Export "missing block at index" error

### DIFF
--- a/.changeset/export_missing_block_at_index_error.md
+++ b/.changeset/export_missing_block_at_index_error.md
@@ -1,0 +1,15 @@
+---
+default: patch
+---
+
+# Export 'missing block at index' error
+
+#217 by @chris124567
+
+The "missing block at index" error is used in multiple places to detect that a chain migration happened so that the app knows to reset whatever state it stored previously.  This PR exports it so that looking at the error string is not necessary.
+
+https://github.com/SiaFoundation/hostd/blob/711ac3eb1da09e4d6a9ff17a2efe3555d70b8185/index/update.go#L36
+https://github.com/SiaFoundation/walletd/blob/d91147b7ec52b2261779949905c8e0fd3c0ad5c7/wallet/manager.go#L733
+
+And recently in explored:
+https://github.com/SiaFoundation/explored/pull/212/files#diff-b973ebcbcd81d6f5eb333f7b87b7366e9886270ccdef647b80df03f94a1156dcR185

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -14,6 +14,9 @@ import (
 )
 
 var (
+	// ErrMissingBlock is returned when we do not have a block at the given
+	// index.
+	ErrMissingBlock = errors.New("missing block at index")
 	// ErrFutureBlock is returned when a block's timestamp is too far in the future.
 	ErrFutureBlock = errors.New("block's timestamp is too far in the future")
 )
@@ -284,7 +287,7 @@ func (m *Manager) markBadBlock(bid types.BlockID, err error) {
 func (m *Manager) revertTip() error {
 	b, bs, cs, ok := blockAndParent(m.store, m.tipState.Index.ID)
 	if !ok {
-		return fmt.Errorf("missing block at index %v", m.tipState.Index)
+		return fmt.Errorf("%w %v", ErrMissingBlock, m.tipState.Index)
 	}
 	cru := consensus.RevertBlock(cs, b, *bs)
 	m.store.RevertBlock(cs, cru)
@@ -298,7 +301,7 @@ func (m *Manager) applyTip(index types.ChainIndex) error {
 	var cau consensus.ApplyUpdate
 	b, bs, cs, ok := blockAndChild(m.store, index.ID)
 	if !ok {
-		return fmt.Errorf("missing block at index %v", index)
+		return fmt.Errorf("%w %v", ErrMissingBlock, index)
 	} else if b.ParentID != m.tipState.Index.ID {
 		panic("applyTip called with non-attaching block")
 	} else if bs == nil {
@@ -432,7 +435,7 @@ func (m *Manager) UpdatesSince(index types.ChainIndex, maxBlocks int) (rus []Rev
 		if !onBestChain(index) {
 			b, bs, cs, ok := blockAndParent(m.store, index.ID)
 			if !ok {
-				return nil, nil, fmt.Errorf("missing block at index %v", index)
+				return nil, nil, fmt.Errorf("%w %v", ErrMissingBlock, index)
 			} else if bs == nil {
 				return nil, nil, fmt.Errorf("missing supplement for block %v", index)
 			}
@@ -448,7 +451,7 @@ func (m *Manager) UpdatesSince(index types.ChainIndex, maxBlocks int) (rus []Rev
 			}
 			b, bs, cs, ok := blockAndParent(m.store, index.ID)
 			if !ok {
-				return nil, nil, fmt.Errorf("missing block at index %v", index)
+				return nil, nil, fmt.Errorf("%w %v", ErrMissingBlock, index)
 			} else if bs == nil {
 				return nil, nil, fmt.Errorf("missing supplement for block %v", index)
 			}


### PR DESCRIPTION
The "missing block at index" error is used in multiple places to detect that a chain migration happened so that the app knows to reset whatever state it stored previously.  This PR exports it so that looking at the error string is not necessary and `errors.Is` can be used.

https://github.com/SiaFoundation/hostd/blob/711ac3eb1da09e4d6a9ff17a2efe3555d70b8185/index/update.go#L36
https://github.com/SiaFoundation/walletd/blob/d91147b7ec52b2261779949905c8e0fd3c0ad5c7/wallet/manager.go#L733

And recently in explored:
https://github.com/SiaFoundation/explored/pull/212/files#diff-b973ebcbcd81d6f5eb333f7b87b7366e9886270ccdef647b80df03f94a1156dcR185