### PR TITLE
Consistently return `rhp4.ErrInvalidSignature`

### DIFF
--- a/.changeset/return_rhp4errinvalidsignature_consistently_when_we_fail_to_validate_the_challenge_signature.md
+++ b/.changeset/return_rhp4errinvalidsignature_consistently_when_we_fail_to_validate_the_challenge_signature.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Return rhp4.ErrInvalidSignature consistently when we fail to validate the challenge signature.

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -1771,24 +1771,11 @@ func TestRPCSectorRoots(t *testing.T) {
 		checkRoots(t, roots)
 	}
 
-	// store random sectors on the host
-	data := frand.Bytes(1024)
-	writeResult, err := rhp4.RPCWriteSector(context.Background(), transport, settings.Prices, token, bytes.NewReader(data), uint64(len(data)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	roots = append(roots, writeResult.Root)
-
 	// assert manipulating the signature returns [proto4.ErrInvalidSignature]
 	corrupted := revision
 	corrupted.Revision.RevisionNumber++
-	_, err = rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, corrupted, []types.Hash256{writeResult.Root})
+	_, err = rhp4.RPCSectorRoots(context.Background(), transport, cs, settings.Prices, renterKey, corrupted, 0, 1)
 	if err == nil || !strings.Contains(err.Error(), proto4.ErrInvalidSignature.Error()) {
-		t.Fatal(err)
-	}
-
-	_, err = rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, []types.Hash256{writeResult.Root})
-	if err != nil {
 		t.Fatal(err)
 	}
 }

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -892,7 +892,7 @@ func TestSiamuxDialUpgradeTimeout(t *testing.T) {
 	})
 }
 
-func TestReplenishAccounts(t *testing.T) {
+func TestRPCReplenishAccounts(t *testing.T) {
 	n, genesis := testutil.V2Network()
 	hostKey, renterKey := types.GeneratePrivateKey(), types.GeneratePrivateKey()
 
@@ -980,8 +980,16 @@ func TestReplenishAccounts(t *testing.T) {
 		})
 	}
 
+	// assert manipulating the signature returns [proto4.ErrInvalidSignature]
+	corrupted := revision
+	corrupted.Revision.RevisionNumber++
+	fundResult, err := rhp4.RPCFundAccounts(context.Background(), transport, cs, renterKey, corrupted, deposits)
+	if err == nil || !strings.Contains(err.Error(), proto4.ErrInvalidSignature.Error()) {
+		t.Fatal(err)
+	}
+
 	// fund the initial set of accounts
-	fundResult, err := rhp4.RPCFundAccounts(context.Background(), transport, cs, renterKey, revision, deposits)
+	fundResult, err = rhp4.RPCFundAccounts(context.Background(), transport, cs, renterKey, revision, deposits)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1010,8 +1018,16 @@ func TestReplenishAccounts(t *testing.T) {
 		}
 	}
 
+	// assert manipulating the signature returns [proto4.ErrInvalidSignature]
+	corruptedParams := replenishParams
+	corruptedParams.Contract.Revision.RevisionNumber++
+	replenishResult, err := rhp4.RPCReplenishAccounts(context.Background(), transport, corruptedParams, cs, fundAndSign)
+	if err == nil || !strings.Contains(err.Error(), proto4.ErrInvalidSignature.Error()) {
+		t.Fatal(err)
+	}
+
 	// replenish the accounts
-	replenishResult, err := rhp4.RPCReplenishAccounts(context.Background(), transport, replenishParams, cs, fundAndSign)
+	replenishResult, err = rhp4.RPCReplenishAccounts(context.Background(), transport, replenishParams, cs, fundAndSign)
 	if err != nil {
 		t.Fatal(err)
 	} else if !replenishResult.Usage.AccountFunding.Equals(expectedCost) {
@@ -1398,8 +1414,16 @@ func TestAppendSectors(t *testing.T) {
 	excludedIndex := frand.Intn(len(roots))
 	roots[excludedIndex] = frand.Entropy256()
 
+	// assert manipulating the signature returns [proto4.ErrInvalidSignature]
+	corrupted := revision
+	corrupted.Revision.RevisionNumber++
+	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, corrupted, roots)
+	if err == nil || !strings.Contains(err.Error(), proto4.ErrInvalidSignature.Error()) {
+		t.Fatal(err)
+	}
+
 	// append the sectors to the contract
-	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, roots)
+	appendResult, err = rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, roots)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(appendResult.Sectors) != len(roots)-1 {
@@ -1626,7 +1650,15 @@ func TestRPCFreeSectors(t *testing.T) {
 	}
 	newRoots = newRoots[:len(newRoots)-len(indices)]
 
-	removeResult, err := rhp4.RPCFreeSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, indices)
+	// assert manipulating the signature returns [proto4.ErrInvalidSignature]
+	corrupted := revision
+	corrupted.Revision.RevisionNumber++
+	removeResult, err := rhp4.RPCFreeSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, corrupted, indices)
+	if err == nil || !strings.Contains(err.Error(), proto4.ErrInvalidSignature.Error()) {
+		t.Fatal(err)
+	}
+
+	removeResult, err = rhp4.RPCFreeSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, indices)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1737,6 +1769,27 @@ func TestRPCSectorRoots(t *testing.T) {
 		revision.Revision = appendResult.Revision
 		assertValidRevision(t, cm, c, revision)
 		checkRoots(t, roots)
+	}
+
+	// store random sectors on the host
+	data := frand.Bytes(1024)
+	writeResult, err := rhp4.RPCWriteSector(context.Background(), transport, settings.Prices, token, bytes.NewReader(data), uint64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots = append(roots, writeResult.Root)
+
+	// assert manipulating the signature returns [proto4.ErrInvalidSignature]
+	corrupted := revision
+	corrupted.Revision.RevisionNumber++
+	_, err = rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, corrupted, []types.Hash256{writeResult.Root})
+	if err == nil || !strings.Contains(err.Error(), proto4.ErrInvalidSignature.Error()) {
+		t.Fatal(err)
+	}
+
+	_, err = rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, []types.Hash256{writeResult.Root})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
If we want to store revisions in the database to avoid fetching the latest revision right before revising the contract, we need the host to return `rhp4.ErrInvalidSignature` consistently so we can check for it. Our RPCs expect two types of signatures, a challenge signature that proves we can modify the contract, or a signature that covers the new revision. This PR updates 3 locations where we weren't returning `rhp4.ErrInvalidSignature` when we failed to validate the challenge signature.

Related to https://github.com/SiaFoundation/indexd/issues/144