### PR TITLE
Consistently use ContractSigner interface

### DIFF
--- a/.changeset/changed_rpcappendsectors_and_rpcfreesectors_methods_to_use_contractsigner_instead_of_taking_a_private_key_directly.md
+++ b/.changeset/changed_rpcappendsectors_and_rpcfreesectors_methods_to_use_contractsigner_instead_of_taking_a_private_key_directly.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Changed RPCAppendSectors and RPCFreeSectors methods to use ContractSigner instead of taking a private key directly

--- a/rhp/v4/rpc.go
+++ b/rhp/v4/rpc.go
@@ -381,13 +381,13 @@ func RPCVerifySector(ctx context.Context, t TransportClient, prices rhp4.HostPri
 }
 
 // RPCFreeSectors removes sectors from a contract.
-func RPCFreeSectors(ctx context.Context, t TransportClient, cs consensus.State, prices rhp4.HostPrices, sk types.PrivateKey, contract ContractRevision, indices []uint64) (RPCFreeSectorsResult, error) {
+func RPCFreeSectors(ctx context.Context, t TransportClient, signer ContractSigner, cs consensus.State, prices rhp4.HostPrices, contract ContractRevision, indices []uint64) (RPCFreeSectorsResult, error) {
 	req := rhp4.RPCFreeSectorsRequest{
 		ContractID: contract.ID,
 		Prices:     prices,
 		Indices:    indices,
 	}
-	req.ChallengeSignature = sk.SignHash(req.ChallengeSigHash(contract.Revision.RevisionNumber + 1))
+	req.ChallengeSignature = signer.SignHash(req.ChallengeSigHash(contract.Revision.RevisionNumber + 1))
 
 	s, err := openStream(ctx, t, defaultStreamTimeout)
 	if err != nil {
@@ -413,7 +413,7 @@ func RPCFreeSectors(ctx context.Context, t TransportClient, cs consensus.State, 
 	}
 
 	sigHash := cs.ContractSigHash(revision)
-	revision.RenterSignature = sk.SignHash(sigHash)
+	revision.RenterSignature = signer.SignHash(sigHash)
 
 	signatureResp := rhp4.RPCFreeSectorsSecondResponse{
 		RenterSignature: revision.RenterSignature,
@@ -439,13 +439,13 @@ func RPCFreeSectors(ctx context.Context, t TransportClient, cs consensus.State, 
 }
 
 // RPCAppendSectors appends sectors a host is storing to a contract.
-func RPCAppendSectors(ctx context.Context, t TransportClient, cs consensus.State, prices rhp4.HostPrices, sk types.PrivateKey, contract ContractRevision, roots []types.Hash256) (RPCAppendSectorsResult, error) {
+func RPCAppendSectors(ctx context.Context, t TransportClient, signer ContractSigner, cs consensus.State, prices rhp4.HostPrices, contract ContractRevision, roots []types.Hash256) (RPCAppendSectorsResult, error) {
 	req := rhp4.RPCAppendSectorsRequest{
 		Prices:     prices,
 		Sectors:    roots,
 		ContractID: contract.ID,
 	}
-	req.ChallengeSignature = sk.SignHash(req.ChallengeSigHash(contract.Revision.RevisionNumber + 1))
+	req.ChallengeSignature = signer.SignHash(req.ChallengeSigHash(contract.Revision.RevisionNumber + 1))
 
 	s, err := openStream(ctx, t, defaultStreamTimeout)
 	if err != nil {
@@ -479,7 +479,7 @@ func RPCAppendSectors(ctx context.Context, t TransportClient, cs consensus.State
 		return RPCAppendSectorsResult{}, fmt.Errorf("failed to revise contract: %w", err)
 	}
 	sigHash := cs.ContractSigHash(revision)
-	revision.RenterSignature = sk.SignHash(sigHash)
+	revision.RenterSignature = signer.SignHash(sigHash)
 
 	signatureResp := rhp4.RPCAppendSectorsSecondResponse{
 		RenterSignature: revision.RenterSignature,

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -514,7 +514,7 @@ func TestRPCRefresh(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		aRes, err := rhp4.RPCAppendSectors(context.Background(), transport, cs, settings.Prices, renterKey, revision, []types.Hash256{wRes.Root})
+		aRes, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, []types.Hash256{wRes.Root})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -668,7 +668,7 @@ func TestRPCRenew(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		aRes, err := rhp4.RPCAppendSectors(context.Background(), transport, cs, settings.Prices, renterKey, revision, []types.Hash256{wRes.Root})
+		aRes, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, []types.Hash256{wRes.Root})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1399,7 +1399,7 @@ func TestAppendSectors(t *testing.T) {
 	roots[excludedIndex] = frand.Entropy256()
 
 	// append the sectors to the contract
-	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, cs, settings.Prices, renterKey, revision, roots)
+	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, roots)
 	if err != nil {
 		t.Fatal(err)
 	} else if len(appendResult.Sectors) != len(roots)-1 {
@@ -1608,7 +1608,7 @@ func TestRPCFreeSectors(t *testing.T) {
 	}
 
 	// append all the sector roots to the contract
-	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, cs, settings.Prices, renterKey, revision, roots)
+	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, roots)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1626,7 +1626,7 @@ func TestRPCFreeSectors(t *testing.T) {
 	}
 	newRoots = newRoots[:len(newRoots)-len(indices)]
 
-	removeResult, err := rhp4.RPCFreeSectors(context.Background(), transport, cs, settings.Prices, renterKey, revision, indices)
+	removeResult, err := rhp4.RPCFreeSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, indices)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1730,7 +1730,7 @@ func TestRPCSectorRoots(t *testing.T) {
 		}
 		roots = append(roots, writeResult.Root)
 
-		appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, cs, settings.Prices, renterKey, revision, []types.Hash256{writeResult.Root})
+		appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, []types.Hash256{writeResult.Root})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2010,7 +2010,7 @@ func BenchmarkContractUpload(b *testing.B) {
 
 	wg.Wait()
 
-	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, cs, settings.Prices, renterKey, revision, roots)
+	appendResult, err := rhp4.RPCAppendSectors(context.Background(), transport, fundAndSign, cs, settings.Prices, revision, roots)
 	if err != nil {
 		b.Fatal(err)
 	} else if appendResult.Revision.Filesize != uint64(b.N)*proto4.SectorSize {


### PR DESCRIPTION
Changes RPCAppendSectors and RPCFreeSectors to use `ContractSigner` like the other methods that require a contract signature