### PR TITLE
Remove sticky error from mempool

### DIFF
--- a/.changeset/removed_invalid_transaction_sets_sticky_error.md
+++ b/.changeset/removed_invalid_transaction_sets_sticky_error.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Removed invalid transaction set sticky error

--- a/miner_test.go
+++ b/miner_test.go
@@ -60,13 +60,14 @@ func TestMiner(t *testing.T) {
 	}
 
 	// assert the minerpayout includes the txn fee
+	expectedPayout := types.Siacoins(1).Add(cm.TipState().BlockReward())
 	b, found := coreutils.MineBlock(cm, types.VoidAddress, time.Second)
 	if !found {
 		t.Fatal("PoW failed")
 	} else if len(b.MinerPayouts) != 1 {
 		t.Fatal("expected one miner payout")
-	} else if b.MinerPayouts[0].Value.Cmp(types.Siacoins(1).Add(cm.TipState().BlockReward())) != 0 {
-		t.Fatal("unexpected miner payout", b.MinerPayouts[0].Value.ExactString())
+	} else if b.MinerPayouts[0].Value.Cmp(expectedPayout) != 0 {
+		t.Fatalf("expected miner payout %d, got %d", expectedPayout, b.MinerPayouts[0].Value)
 	}
 }
 


### PR DESCRIPTION
Removed the sticky error when validating transaction sets because it causes subtle and hard to debug failures when developing.