### PR TITLE
Require peers to support V2 RPCs

### DIFF
--- a/.changeset/require_peers_to_support_v2.md
+++ b/.changeset/require_peers_to_support_v2.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Require peers to support V2.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/quic-go/quic-go v0.52.0
 	github.com/quic-go/webtransport-go v0.8.1-0.20241018022711-4ac2c9250e66
 	go.etcd.io/bbolt v1.4.1
-	go.sia.tech/core v0.13.2
+	go.sia.tech/core v0.13.3-0.20250616154238-4c58987023c7
 	go.sia.tech/mux v1.4.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.etcd.io/bbolt v1.4.1 h1:5mOV+HWjIPLEAlUGMsveaUvK2+byZMFOzojoi7bh7uI=
 go.etcd.io/bbolt v1.4.1/go.mod h1:c8zu2BnXWTu2XM4XcICtbGSl9cFwsXtcf9zLt2OncM8=
-go.sia.tech/core v0.13.2 h1:66ZYzN2+AiHZmRayt4idSfoEoQZ5LV541+2E0luiizA=
-go.sia.tech/core v0.13.2/go.mod h1:bur1jeLA1JQbwzZkc2ijSTdpJYusG4h0pV9IwLOHT0g=
+go.sia.tech/core v0.13.3-0.20250616154238-4c58987023c7 h1:4KCpwSuMMZuiWcSOpQ9GFLpGhIxVdaqOnd4Bz2U590c=
+go.sia.tech/core v0.13.3-0.20250616154238-4c58987023c7/go.mod h1:bur1jeLA1JQbwzZkc2ijSTdpJYusG4h0pV9IwLOHT0g=
 go.sia.tech/mux v1.4.0 h1:LgsLHtn7l+25MwrgaPaUCaS8f2W2/tfvHIdXps04sVo=
 go.sia.tech/mux v1.4.0/go.mod h1:iNFi9ifFb2XhuD+LF4t2HBb4Mvgq/zIPKqwXU/NlqHA=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION
Now that the hardfork has activated it is okay to require all peers to support V2 RPCs.