### PR TITLE
Remove lock persistence

### DIFF
--- a/.changeset/remove_persistence_for_locked_utxos.md
+++ b/.changeset/remove_persistence_for_locked_utxos.md
@@ -1,0 +1,7 @@
+---
+default: major
+---
+
+# Remove persistence for locked UTXOs
+
+Now that the tpool is persisted, UTXOs that have been broadcast will be readded on startup. This should mean that locked UTXOs can be ephemeral again since their primary purpose is to prevent double spends during RPCs.

--- a/.changeset/removed_unused_syncer_interface_from_rhp4_server.md
+++ b/.changeset/removed_unused_syncer_interface_from_rhp4_server.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Removed unused syncer interface from RHP4 server.

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -41,12 +41,6 @@ func (b *blockingSettingsReporter) Unblock() {
 	close(b.blockChan)
 }
 
-type syncerMock struct{}
-
-func (syncerMock) BroadcastV2TransactionSet(types.ChainIndex, []types.V2Transaction) error {
-	return nil
-}
-
 type fundAndSign struct {
 	w  *wallet.SingleAddressWallet
 	pk types.PrivateKey
@@ -76,7 +70,7 @@ func (fs *fundAndSign) Address() types.Address {
 }
 
 func testRenterHostPairSiaMux(tb testing.TB, hostKey types.PrivateKey, cm rhp4.ChainManager, w rhp4.Wallet, c rhp4.Contractor, sr rhp4.Settings, ss rhp4.Sectors, log *zap.Logger) rhp4.TransportClient {
-	rs := rhp4.NewServer(hostKey, cm, &syncerMock{}, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
+	rs := rhp4.NewServer(hostKey, cm, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	hostAddr := testutil.ServeSiaMux(tb, rs, log.Named("siamux"))
 
 	transport, err := siamux.Dial(context.Background(), hostAddr, hostKey.PublicKey())
@@ -89,7 +83,7 @@ func testRenterHostPairSiaMux(tb testing.TB, hostKey types.PrivateKey, cm rhp4.C
 }
 
 func testRenterHostPairQUIC(tb testing.TB, hostKey types.PrivateKey, cm rhp4.ChainManager, w rhp4.Wallet, c rhp4.Contractor, sr rhp4.Settings, ss rhp4.Sectors, log *zap.Logger) rhp4.TransportClient {
-	rs := rhp4.NewServer(hostKey, cm, &syncerMock{}, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
+	rs := rhp4.NewServer(hostKey, cm, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	hostAddr := testutil.ServeQUIC(tb, rs, log.Named("quic"))
 
 	transport, err := quic.Dial(context.Background(), hostAddr, hostKey.PublicKey(), quic.WithTLSConfig(func(tc *tls.Config) {
@@ -903,7 +897,7 @@ func TestSiamuxDialUpgradeTimeout(t *testing.T) {
 
 	sr := testutil.NewEphemeralSettingsReporter()
 	hk := types.GeneratePrivateKey()
-	rs := rhp4.NewServer(hk, cm, &syncerMock{}, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
+	rs := rhp4.NewServer(hk, cm, c, w, sr, ss, rhp4.WithPriceTableValidity(2*time.Minute))
 	hostAddr := testutil.ServeSiaMux(t, rs, zap.NewNop())
 
 	t.Run("dial", func(t *testing.T) {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -25,7 +25,8 @@ type (
 	}
 )
 
-func (s *MockSyncer) Calls() []broadcastCall {
+// BroadcastCalls returns the calls made to the MockSyncer
+func (s *MockSyncer) BroadcastCalls() []broadcastCall {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.calls

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -16,17 +16,18 @@ type (
 	// the peer check
 	MockSyncer struct {
 		mu    sync.Mutex
-		calls []broadcastCall
+		calls []MockBroadcastCall
 	}
 
-	broadcastCall struct {
+	// A MockBroadcastCall is a call to broadcast a transaction set made to the MockSyncer
+	MockBroadcastCall struct {
 		Index types.ChainIndex
 		Txns  []types.V2Transaction
 	}
 )
 
 // BroadcastCalls returns the calls made to the MockSyncer
-func (s *MockSyncer) BroadcastCalls() []broadcastCall {
+func (s *MockSyncer) BroadcastCalls() []MockBroadcastCall {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.calls
@@ -36,7 +37,7 @@ func (s *MockSyncer) BroadcastCalls() []broadcastCall {
 func (s *MockSyncer) BroadcastV2TransactionSet(index types.ChainIndex, txns []types.V2Transaction) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.calls = append(s.calls, broadcastCall{Index: index, Txns: txns})
+	s.calls = append(s.calls, MockBroadcastCall{Index: index, Txns: txns})
 	return nil
 }
 

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -30,7 +31,7 @@ type (
 func (s *MockSyncer) BroadcastCalls() []MockBroadcastCall {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.calls
+	return slices.Clone(s.calls)
 }
 
 // BroadcastV2TransactionSet implements the syncer.Syncer interface

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1988,7 +1988,7 @@ func TestRebroadcastTransaction(t *testing.T) {
 	}
 
 	// assert the set was broadcasted twice
-	if calls := s.Calls(); len(calls) != 2 {
+	if calls := s.BroadcastCalls(); len(calls) != 2 {
 		t.Fatalf("expected 2 calls to BroadcastV2TransactionSet, got %v", len(calls))
 	} else if calls[0].Index != basis || !reflect.DeepEqual(calls[0].Txns, set) {
 		t.Fatal("unexpected first call to BroadcastV2TransactionSet")
@@ -2021,7 +2021,7 @@ func TestRebroadcastTransaction(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// assert the set was rebroadcasted
-	if calls := s.Calls(); len(calls) == 2 {
+	if calls := s.BroadcastCalls(); len(calls) == 2 {
 		t.Fatal("expected set to have been rebroadcasted")
 	} else if len(calls[len(calls)-1].Txns) != 1 || calls[len(calls)-1].Txns[0].ID() != txn2.ID() {
 		t.Fatal("expected only to have rebroadcasted a single transaction")

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1988,11 +1988,11 @@ func TestRebroadcastTransaction(t *testing.T) {
 	}
 
 	// assert the set was broadcasted twice
-	if len(s.Calls) != 2 {
-		t.Fatalf("expected 2 calls to BroadcastV2TransactionSet, got %v", len(s.Calls))
-	} else if s.Calls[0].Index != basis || !reflect.DeepEqual(s.Calls[0].Txns, set) {
+	if calls := s.Calls(); len(calls) != 2 {
+		t.Fatalf("expected 2 calls to BroadcastV2TransactionSet, got %v", len(calls))
+	} else if calls[0].Index != basis || !reflect.DeepEqual(calls[0].Txns, set) {
 		t.Fatal("unexpected first call to BroadcastV2TransactionSet")
-	} else if s.Calls[1].Index != basis || !reflect.DeepEqual(s.Calls[1].Txns, set) {
+	} else if calls[1].Index != basis || !reflect.DeepEqual(calls[1].Txns, set) {
 		t.Fatal("unexpected second call to BroadcastV2TransactionSet")
 	}
 
@@ -2021,9 +2021,9 @@ func TestRebroadcastTransaction(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// assert the set was rebroadcasted
-	if len(s.Calls) == 2 {
+	if calls := s.Calls(); len(calls) == 2 {
 		t.Fatal("expected set to have been rebroadcasted")
-	} else if len(s.Calls[len(s.Calls)-1].Txns) != 1 || s.Calls[len(s.Calls)-1].Txns[0].ID() != txn2.ID() {
+	} else if len(calls[len(calls)-1].Txns) != 1 || calls[len(calls)-1].Txns[0].ID() != txn2.ID() {
 		t.Fatal("expected only to have rebroadcasted a single transaction")
 	}
 


### PR DESCRIPTION
Now that the tpool is persisted in #276, UTXOs that have been broadcast and are still valid should be implicitly relocked on startup. This should mean that locked UTXOs can be ephemeral again since their primary purpose is to prevent double spends during async RPCs (if the RPC doesn't complete, there's no reason to keep them locked).