### PR TITLE
Fix RPCError code and add `DeleteSector`

### DIFF
--- a/.changeset/fix_rpcerror_code_in_rpcverifysector.md
+++ b/.changeset/fix_rpcerror_code_in_rpcverifysector.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Fix RPCError code in RPCVerifySector

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -1168,6 +1168,11 @@ func TestAccounts(t *testing.T) {
 
 	cs := cm.TipState()
 
+	var sector *[proto4.SectorSize]byte
+	if err := ss.StoreSector(types.Hash256{1}, sector, 0); err != nil {
+		t.Fatal(err)
+	}
+
 	// test operations against unknown account
 	token := account.Token(renterKey, hostKey.PublicKey())
 	_, err = rhp4.RPCVerifySector(context.Background(), transport, settings.Prices, token, types.Hash256{1})

--- a/rhp/v4/server.go
+++ b/rhp/v4/server.go
@@ -1118,7 +1118,7 @@ func (s *Server) handleRPCVerifySector(stream net.Conn) error {
 
 	sector, err := s.sectors.ReadSector(req.Root)
 	if err != nil {
-		return rhp4.NewRPCError(rhp4.ErrorCodeBadRequest, err.Error())
+		return rhp4.NewRPCError(rhp4.ErrorCodeHostError, err.Error())
 	}
 
 	proof := rhp4.BuildSectorProof(sector, req.LeafIndex, req.LeafIndex+1)

--- a/testutil/host.go
+++ b/testutil/host.go
@@ -56,6 +56,17 @@ type EphemeralSectorStore struct {
 
 var _ rhp4.Sectors = (*EphemeralSectorStore)(nil)
 
+// DeleteSector deletes a sector from the store.
+func (es *EphemeralSectorStore) DeleteSector(root types.Hash256) error {
+	es.mu.Lock()
+	defer es.mu.Unlock()
+	if _, ok := es.sectors[root]; !ok {
+		return errors.New("sector not found")
+	}
+	delete(es.sectors, root)
+	return nil
+}
+
 // HasSector checks if a sector is stored in the store.
 func (es *EphemeralSectorStore) HasSector(root types.Hash256) (bool, error) {
 	es.mu.Lock()

--- a/testutil/host.go
+++ b/testutil/host.go
@@ -61,7 +61,7 @@ func (es *EphemeralSectorStore) DeleteSector(root types.Hash256) error {
 	es.mu.Lock()
 	defer es.mu.Unlock()
 	if _, ok := es.sectors[root]; !ok {
-		return errors.New("sector not found")
+		return proto4.ErrSectorNotFound
 	}
 	delete(es.sectors, root)
 	return nil
@@ -81,7 +81,7 @@ func (es *EphemeralSectorStore) ReadSector(root types.Hash256) (*[proto4.SectorS
 	defer es.mu.Unlock()
 	sector, ok := es.sectors[root]
 	if !ok {
-		return nil, errors.New("sector not found")
+		return nil, proto4.ErrSectorNotFound
 	}
 	return sector, nil
 }


### PR DESCRIPTION
Testing data integrity in `indexd` I noticed the `RPCError` returned by RPCVerifySector has a wrong code. I also extended the `EphemeralSectorStore` with a `DeleteSector` to enable mocking a host that lost it.