### PR TITLE
Display migration progress more human-friendly

### DIFF
--- a/.changeset/fix_migration_logging.md
+++ b/.changeset/fix_migration_logging.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Display migration progress more human-friendly.

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -3,6 +3,7 @@ package chain
 import (
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"go.sia.tech/core/consensus"
@@ -37,7 +38,7 @@ func (zl *zapMigrationLogger) SetProgress(percentage float64) {
 	if time.Since(zl.lastProgressReport) < 30*time.Second {
 		return
 	}
-	zl.logger.Info("migration progress", zap.String("progress", fmt.Sprintf("%.1f%%", percentage)))
+	zl.logger.Info("migration progress", zap.Float64("progress", math.Round(percentage*10)/10))
 	zl.lastProgressReport = time.Now()
 }
 

--- a/chain/migrate.go
+++ b/chain/migrate.go
@@ -37,7 +37,7 @@ func (zl *zapMigrationLogger) SetProgress(percentage float64) {
 	if time.Since(zl.lastProgressReport) < 30*time.Second {
 		return
 	}
-	zl.logger.Info("migration progress", zap.Float64("progress", percentage))
+	zl.logger.Info("migration progress", zap.String("progress", fmt.Sprintf("%.1f%%", percentage)))
 	zl.lastProgressReport = time.Now()
 }
 


### PR DESCRIPTION
With this fix, the database migration progress should be displayed in the form

`{"progress": "54.8%"}`

instead of

`{"progress": 54.82123124754181}`