### PR TITLE
Increase RHP4 RPC timeout

### DIFF
--- a/.changeset/increase_rhp4_rpc_timeout_to_5_minutes.md
+++ b/.changeset/increase_rhp4_rpc_timeout_to_5_minutes.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-# Increase default RHP4 RPC timeout to 5 minutes.
+# Increase default RHP4 RPC timeout to 3 minutes.

--- a/.changeset/increase_rhp4_rpc_timeout_to_5_minutes.md
+++ b/.changeset/increase_rhp4_rpc_timeout_to_5_minutes.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Increase default RHP4 RPC timeout to 5 minutes.

--- a/rhp/v4/server.go
+++ b/rhp/v4/server.go
@@ -1150,7 +1150,7 @@ func (s *Server) handleHostStream(stream net.Conn, log *zap.Logger) {
 		}
 	}()
 
-	stream.SetDeadline(time.Now().Add(5 * time.Minute)) // RPC timeout
+	stream.SetDeadline(time.Now().Add(3 * time.Minute)) // RPC timeout
 	rpcStart := time.Now()
 	id, err := rhp4.ReadID(stream)
 	if err != nil {

--- a/rhp/v4/server.go
+++ b/rhp/v4/server.go
@@ -1150,7 +1150,7 @@ func (s *Server) handleHostStream(stream net.Conn, log *zap.Logger) {
 		}
 	}()
 
-	stream.SetDeadline(time.Now().Add(30 * time.Second)) // set an initial timeout
+	stream.SetDeadline(time.Now().Add(5 * time.Minute)) // RPC timeout
 	rpcStart := time.Now()
 	id, err := rhp4.ReadID(stream)
 	if err != nil {


### PR DESCRIPTION
Some people are reporting uploading issues after RHP4 likely related to timeouts being too low now.
This increases the timeout to 5 minutes, to match the previous RHP3 timeout in `handleRPCExecute`.

Related to https://github.com/SiaFoundation/renterd/issues/1948#issuecomment-3172784475