### PR TITLE
Instant syncing

### DIFF
--- a/.changeset/instant_syncing.md
+++ b/.changeset/instant_syncing.md
@@ -4,34 +4,4 @@ default: minor
 
 # Instant syncing
 
-#332 by @lukechampine
-
 Adds a new chain.DB constructor and a helper function for fetching checkpoints.
-
-Example usage:
-
-```go
-func main() {
-	var peer string
-	var index types.ChainIndex
-	flag.TextVar(&index, "index", types.ChainIndex{}, "trusted chain index to bootstrap from")
-	flag.StringVar(&peer, "peer", "", "peer to bootstrap from")
-	flag.Parse()
-	n, genesisBlock := chain.Mainnet()
-	cs, b, err := syncer.SendCheckpoint(context.Background(), peer, index, n, genesisBlock.ID())
-	if err != nil {
-		log.Fatal(err)
-	}
-	store, tipState, err := chain.NewDBStoreAtCheckpoint(chain.NewMemDB(), cs, b, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
-	cm := chain.NewManager(store, tipState)
-	fmt.Println("Initialized chain.Manager at", cm.Tip())
-}
-```
-
-```
-./example -peer "174.97.109.105:9981" -index "530000::0000000000000000abb98e3b587fba3a0c4e723ac1e078e9d6a4d13d1d131a2c"
-Initialized chain.Manager at 530000::1d131a2c
-```

--- a/.changeset/instant_syncing.md
+++ b/.changeset/instant_syncing.md
@@ -1,0 +1,37 @@
+---
+default: minor
+---
+
+# Instant syncing
+
+#332 by @lukechampine
+
+Adds a new chain.DB constructor and a helper function for fetching checkpoints.
+
+Example usage:
+
+```go
+func main() {
+	var peer string
+	var index types.ChainIndex
+	flag.TextVar(&index, "index", types.ChainIndex{}, "trusted chain index to bootstrap from")
+	flag.StringVar(&peer, "peer", "", "peer to bootstrap from")
+	flag.Parse()
+	n, genesisBlock := chain.Mainnet()
+	cs, b, err := syncer.SendCheckpoint(context.Background(), peer, index, n, genesisBlock.ID())
+	if err != nil {
+		log.Fatal(err)
+	}
+	store, tipState, err := chain.NewDBStoreAtCheckpoint(chain.NewMemDB(), cs, b, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cm := chain.NewManager(store, tipState)
+	fmt.Println("Initialized chain.Manager at", cm.Tip())
+}
+```
+
+```
+./example -peer "174.97.109.105:9981" -index "530000::0000000000000000abb98e3b587fba3a0c4e723ac1e078e9d6a4d13d1d131a2c"
+Initialized chain.Manager at 530000::1d131a2c
+```

--- a/syncer/syncer_test.go
+++ b/syncer/syncer_test.go
@@ -186,6 +186,47 @@ func TestSendCheckpoint(t *testing.T) {
 	}
 }
 
+func TestInstantSync(t *testing.T) {
+	n, genesis := testutil.Network()
+	log := zap.NewNop()
+
+	s, cm := newTestSyncer(t, "syncer", log)
+	defer s.Close()
+
+	// mine a few blocks above v2 hardfork height
+	testutil.MineBlocks(t, cm, types.VoidAddress, int(n.HardforkV2.AllowHeight+10))
+
+	// instant sync to 5 blocks below the tip
+	index, ok := cm.BestIndex(cm.Tip().Height - 5)
+	if !ok {
+		t.Fatal("failed to get index")
+	}
+	cs, b, err := syncer.SendCheckpoint(context.Background(), s.Addr(), index, n, genesis.ID())
+	if err != nil {
+		t.Fatal(err)
+	} else if cs.Index.ID != b.ParentID {
+		t.Fatalf("expected checkpoint state %v, got %v", b.ParentID, cs.Index.ID)
+	}
+	// initialize new manager at synced checkpoint
+	store, newTipState, err := chain.NewDBStoreAtCheckpoint(chain.NewMemDB(), cs, b, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm2 := chain.NewManager(store, newTipState)
+
+	if cm2.Tip() != index {
+		t.Fatalf("expected tip %v, got %v", index, cm2.Tip())
+	} else if b2, ok := cm2.Block(b.ID()); !ok {
+		t.Fatal("checkpoint block not stored")
+	} else if !hashEq(types.V2Block(b2), types.V2Block(b)) {
+		t.Fatalf("checkpoint block mismatch")
+	} else if cs2, ok := cm2.State(cs.Index.ID); !ok {
+		t.Fatal("parent state not stored")
+	} else if !hashEq(cs2, cs) {
+		t.Fatalf("parent state mismatch")
+	}
+}
+
 func TestSendHeaders(t *testing.T) {
 	log := zaptest.NewLogger(t)
 


### PR DESCRIPTION
Adds a new chain.DB constructor and a helper function for fetching checkpoints.

Example usage:

```go
func main() {
	var peer string
	var index types.ChainIndex
	flag.TextVar(&index, "index", types.ChainIndex{}, "trusted chain index to bootstrap from")
	flag.StringVar(&peer, "peer", "", "peer to bootstrap from")
	flag.Parse()
	n, genesisBlock := chain.Mainnet()
	cs, b, err := syncer.SendCheckpoint(context.Background(), peer, index, n, genesisBlock.ID())
	if err != nil {
		log.Fatal(err)
	}
	store, tipState, err := chain.NewDBStoreAtCheckpoint(chain.NewMemDB(), cs, b, nil)
	if err != nil {
		log.Fatal(err)
	}
	cm := chain.NewManager(store, tipState)
	fmt.Println("Initialized chain.Manager at", cm.Tip())
}
```

```
./example -peer "174.97.109.105:9981" -index "530000::0000000000000000abb98e3b587fba3a0c4e723ac1e078e9d6a4d13d1d131a2c"
Initialized chain.Manager at 530000::1d131a2c
```