### PR TITLE
Fix rebroadcast edge-case

### DIFF
--- a/.changeset/fixed_an_edge_case_where_transactions_may_make_it_into_the_local_pool_causing_them_to_not_be_rebroadcast.md
+++ b/.changeset/fixed_an_edge_case_where_transactions_may_make_it_into_the_local_pool_causing_them_to_not_be_rebroadcast.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed an edge-case where transactions make it into the local pool causing them to not be broadcast.

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -1162,7 +1162,11 @@ func (m *Manager) updateV2TransactionProofs(txns []types.V2Transaction, from, to
 		return nil, fmt.Errorf("reorg path from %v to %v is too long (-%v +%v)", from, to, len(revert), len(apply))
 	}
 
-	updated = slices.Clone(txns)
+	// work on a deep copy of the transactions
+	updated = make([]types.V2Transaction, 0, len(txns))
+	for _, txn := range txns {
+		updated = append(updated, txn.DeepCopy())
+	}
 	for _, index := range revert {
 		b, bs, cs, ok := blockAndParent(m.store, index.ID)
 		if !ok {

--- a/wallet/config.go
+++ b/wallet/config.go
@@ -13,6 +13,9 @@ type (
 		MaxDefragUTXOs      int
 		ReservationDuration time.Duration
 
+		MaxRebroadcastPeriod        time.Duration
+		RebroadcastDebounceInterval time.Duration
+
 		Log *zap.Logger
 	}
 
@@ -52,6 +55,29 @@ func WithReservationDuration(d time.Duration) Option {
 
 	return func(c *config) {
 		c.ReservationDuration = d
+	}
+}
+
+// WithDebounceInterval sets the debounce interval for rebroadcasting
+// transactions after a reorg.
+func WithDebounceInterval(d time.Duration) Option {
+	if d <= 0 {
+		panic("debounce interval must be positive") // developer error
+	}
+	return func(c *config) {
+		c.RebroadcastDebounceInterval = d
+	}
+}
+
+// WithMaxRebroadcastPeriod sets the maximum period of time a transaction set is
+// being rebroadcasted, after this period the broadcasted set is removed from
+// the store.
+func WithMaxRebroadcastPeriod(d time.Duration) Option {
+	if d <= 0 {
+		panic("max rebroadcast period must be positive") // developer error
+	}
+	return func(c *config) {
+		c.MaxRebroadcastPeriod = d
 	}
 }
 


### PR DESCRIPTION
Fixes an edge case when transactions are rebroadcast. If they manage to make it fully into the local pool, they will no longer be sent to peers even if sending to peers failed. This changes the rebroadcast loop to always send transaction sets that are valid to peers after a reorg.

A good follow-up would be to update the stored sets when processing chain updates in `UpdateChainState`. Right now the rebroadcast interval is 48 hours (lowered from 7 days), but the set can only be updated for 144 blocks.