### PR TITLE
Return connected peers first

### DIFF
--- a/.changeset/return_connected_peers_first_to_avoid_stale_peers_in_the_store.md
+++ b/.changeset/return_connected_peers_first_to_avoid_stale_peers_in_the_store.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Syncer: return connected peers first to avoid stale peers in the store.


### PR DESCRIPTION
Changes the send peers RPC to return connected outbound peers first to avoid sending stale peers from the store.