### PR TITLE
Check resp.DataLength before verifying proof

### DIFF
--- a/.changeset/check_downloaded_data_length_in_rpcreadsector_before_proof_validation_for_a_more_meaningful_error.md
+++ b/.changeset/check_downloaded_data_length_in_rpcreadsector_before_proof_validation_for_a_more_meaningful_error.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Check downloaded data length in RPCReadSector before proof validation for a more meaningful error.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/quic-go/quic-go v0.59.0
 	github.com/quic-go/webtransport-go v0.10.1-0.20260312060737-05fe5253a73c
 	go.etcd.io/bbolt v1.4.3
-	go.sia.tech/core v0.20.0
+	go.sia.tech/core v0.20.1-0.20260505133717-19aaca8844e7
 	go.sia.tech/mux v1.5.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
 go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
-go.sia.tech/core v0.20.0 h1:/KegmrjDgSdnJsbMavGfxShuGA8CfeRQQhulHpB6iys=
-go.sia.tech/core v0.20.0/go.mod h1:nZsd0YjU6slPLkpz0rxLcMJJQTKyp0hxjNIKReF7wBQ=
+go.sia.tech/core v0.20.1-0.20260505133717-19aaca8844e7 h1:h1GK0H42xEa80s+ac2xO7dTjCm9NIgNa+H+fL+7zabI=
+go.sia.tech/core v0.20.1-0.20260505133717-19aaca8844e7/go.mod h1:nZsd0YjU6slPLkpz0rxLcMJJQTKyp0hxjNIKReF7wBQ=
 go.sia.tech/mux v1.5.0 h1:6bQeO5y4AQPcf+UYHjhxpaNX+2V2wI5LIl0BbAg2YDA=
 go.sia.tech/mux v1.5.0/go.mod h1:1/SlgVsLOUsca5tXxAEEwl+Ohm4B8te2YdRhpRGaUZw=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/rhp/v4/rpc.go
+++ b/rhp/v4/rpc.go
@@ -466,10 +466,10 @@ func RPCReadSector(ctx context.Context, t TransportClient, prices rhp4.HostPrice
 	rpv := rhp4.NewRangeProofVerifier(start, end)
 	if n, err := rpv.ReadFrom(io.TeeReader(io.LimitReader(s, int64(resp.DataLength)), w)); err != nil {
 		return RPCReadSectorResult{}, fmt.Errorf("failed to read data: %w", err)
-	} else if !rpv.Verify(resp.Proof, root) {
-		return RPCReadSectorResult{}, ErrInvalidProof
 	} else if n != int64(resp.DataLength) {
 		return RPCReadSectorResult{}, io.ErrUnexpectedEOF
+	} else if !rpv.Verify(resp.Proof, root) {
+		return RPCReadSectorResult{}, ErrInvalidProof
 	}
 	return RPCReadSectorResult{
 		Usage: prices.RPCReadSectorCost(length),


### PR DESCRIPTION
The proof verification is going to fail if we didn't download the full data so we should return a length mismatch first since that's going to be more descriptive than "invalid proof".