### PR TITLE
Fix openStream race between timeout and stream closure

### DIFF
--- a/.changeset/only_set_default_timeout_in_openstream_when_the_context_has_no_deadline_and_handle_context_deadlines_via_goroutine.md
+++ b/.changeset/only_set_default_timeout_in_openstream_when_the_context_has_no_deadline_and_handle_context_deadlines_via_goroutine.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Only set default timeout in openStream when the context has no deadline and handle context deadlines via goroutine.

--- a/rhp/v4/rpc.go
+++ b/rhp/v4/rpc.go
@@ -92,14 +92,10 @@ func openStream(ctx context.Context, t TransportClient, defaultTimeout time.Dura
 		return nil, fmt.Errorf("failed to dial stream: %w", err)
 	}
 
-	var deadline time.Time
-	if dl, ok := ctx.Deadline(); ok {
-		deadline = dl
-	} else if defaultTimeout != 0 {
-		deadline = time.Now().Add(defaultTimeout)
-	}
-	if err := s.SetDeadline(deadline); err != nil {
-		return nil, fmt.Errorf("failed to set default timeout %q: %w", defaultTimeout, err)
+	if _, ok := ctx.Deadline(); !ok && defaultTimeout != 0 {
+		if err := s.SetDeadline(time.Now().Add(defaultTimeout)); err != nil {
+			return nil, fmt.Errorf("failed to set default timeout %q: %w", defaultTimeout, err)
+		}
 	}
 
 	closeChan := make(chan struct{})
@@ -108,11 +104,7 @@ func openStream(ctx context.Context, t TransportClient, defaultTimeout time.Dura
 		case <-ctx.Done():
 		case <-closeChan:
 		}
-		// only close the stream if the stream's deadline wasn't reached to
-		// avoid overwriting a timeout error with a close related error
-		if time.Now().Before(deadline) {
-			s.Close()
-		}
+		s.Close()
 	}()
 	return &timeoutConn{Conn: s, close: closeChan}, nil
 }

--- a/rhp/v4/rpc.go
+++ b/rhp/v4/rpc.go
@@ -84,9 +84,13 @@ func clientErrf(format string, args ...any) error {
 	return rhp4.NewRPCError(rhp4.ErrorCodeClientError, fmt.Sprintf(format, args...))
 }
 
-// openStream dials a stream setting the default timeout. The context deadline will
-// override the default timeout. The stream lifetime is tied to the context.
+// openStream dials a stream setting the default timeout if the context has no
+// deadline. The stream lifetime is tied to the context.
 func openStream(ctx context.Context, t TransportClient, defaultTimeout time.Duration) (net.Conn, error) {
+	if err := context.Cause(ctx); err != nil {
+		return nil, err
+	}
+
 	s, err := t.DialStream(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial stream: %w", err)
@@ -94,6 +98,7 @@ func openStream(ctx context.Context, t TransportClient, defaultTimeout time.Dura
 
 	if _, ok := ctx.Deadline(); !ok && defaultTimeout != 0 {
 		if err := s.SetDeadline(time.Now().Add(defaultTimeout)); err != nil {
+			_ = s.Close()
 			return nil, fmt.Errorf("failed to set default timeout %q: %w", defaultTimeout, err)
 		}
 	}

--- a/rhp/v4/rpc_test.go
+++ b/rhp/v4/rpc_test.go
@@ -1378,7 +1378,7 @@ func TestRPCTimeout(t *testing.T) {
 
 	isTimeoutErr := func(err error) bool {
 		t.Helper()
-		return err != nil && (strings.Contains(err.Error(), "deadline exceeded") || strings.Contains(err.Error(), "i/o timeout"))
+		return err != nil && (strings.Contains(err.Error(), "deadline exceeded") || strings.Contains(err.Error(), "i/o timeout") || strings.Contains(err.Error(), "stream was gracefully closed") || strings.Contains(err.Error(), "canceled by local"))
 	}
 
 	assertRPCTimeout := func(transport rhp4.TransportClient, timeout bool) {


### PR DESCRIPTION
While digging through indexd logs due to a constant flow of failed sector integrity checks I noticed that a fair number of these failed sectors happen due to timeouts. After adding some logging it turns out that we are running into the following race:

- Each integrity check batch has a 5 minute timeout to avoid starving hosts
- That timeout is applied implicitly in `openStream` using `SetDeadline`
- At the same time `openStream` spins up a goroutine to close the stream if `ctx` is closed
- The RPC fails due to `I/o timeout` but `if ctx.Err() != nil` doesn't trigger because the deadline triggers before the context is closed

To avoid this race (because we rely on the context to determine whether an RPC failed due to us aborting it versus something else) this PR updates `openStream` to only rely on the goroutine for all timeouts. Only if no timeout is specified on the context we use `SetDeadline` on the stream with a sane default. Which should never be the case in indexd.

I have deployed this on Zeus for testing and haven't seen any false positives yet.