### PR TITLE
reject nonunique txid transactions from mempool

### DIFF
--- a/.changeset/reject_nonunique_txid_txes_from_mempool.md
+++ b/.changeset/reject_nonunique_txid_txes_from_mempool.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# reject nonunique txid txes from mempool

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -1,6 +1,7 @@
 package chain_test
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -128,42 +129,47 @@ func TestV2Attestations(t *testing.T) {
 		}
 	}
 
-	t.Run("arbitrary data", func(t *testing.T) {
+	sk := types.GeneratePrivateKey()
+	ann := chain.V2HostAnnouncement{
+		{Address: "foo.bar:1234", Protocol: "tcp"},
+	}
+
+	// A transaction that spends no consensus elements stays valid forever and
+	// would be mined in every block, so the txpool must reject it regardless of
+	// any attestations or arbitrary data it carries.
+	t.Run("rejects transactions that spend no elements", func(t *testing.T) {
 		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
 		cm := chain.NewManager(store, tipState)
-		ms := newMemState()
 
-		// mine until a utxo is spendable
-		mineBlocks(t, cm, int(n.MaturityDelay)+1)
-		ms.Sync(t, cm)
-
-		txn := types.V2Transaction{
-			ArbitraryData: frand.Bytes(16),
+		cases := map[string]types.V2Transaction{
+			"arbitrary data only": {
+				ArbitraryData: frand.Bytes(16),
+			},
+			"attestation only": {
+				Attestations: []types.Attestation{ann.ToAttestation(cm.TipState(), sk)},
+			},
+			"arbitrary data + attestation": {
+				ArbitraryData: frand.Bytes(16),
+				Attestations:  []types.Attestation{ann.ToAttestation(cm.TipState(), sk)},
+			},
 		}
-
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn}); err != nil {
-			t.Fatal(err)
+		for name, txn := range cases {
+			t.Run(name, func(t *testing.T) {
+				_, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn})
+				if err == nil || !strings.Contains(err.Error(), "does not spend any elements") {
+					t.Fatalf("expected rejection for transaction that spends no elements, got %v", err)
+				}
+			})
 		}
-
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
-
-		txn2 := types.V2Transaction{
-			ArbitraryData: frand.Bytes(16),
-		}
-
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn2}); err != nil {
-			t.Fatal(err)
-		}
-
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
 	})
 
-	t.Run("arbitrary data + attestation + no change output", func(t *testing.T) {
+	// A funded transaction carrying an attestation and arbitrary data (the host
+	// announcement flow) must still be accepted, and because it spends an input
+	// it must leave the pool once it is mined.
+	t.Run("accepts funded announcement transaction", func(t *testing.T) {
 		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -175,103 +181,6 @@ func TestV2Attestations(t *testing.T) {
 		mineBlocks(t, cm, int(n.MaturityDelay)+1)
 		ms.Sync(t, cm)
 
-		sk := types.GeneratePrivateKey()
-		ann := chain.V2HostAnnouncement{
-			{Address: "foo.bar:1234", Protocol: "tcp"},
-		}
-		se := ms.SpendableElement(t)
-		txn := types.V2Transaction{
-			SiacoinInputs: []types.V2SiacoinInput{
-				{Parent: se.Copy(), SatisfiedPolicy: types.SatisfiedPolicy{Policy: policy}},
-			},
-			MinerFee:      se.SiacoinOutput.Value,
-			ArbitraryData: frand.Bytes(16),
-			Attestations: []types.Attestation{
-				ann.ToAttestation(cm.TipState(), sk),
-			},
-		}
-
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn}); err != nil {
-			t.Fatal(err)
-		}
-
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
-
-		txn2 := types.V2Transaction{
-			Attestations: []types.Attestation{
-				ann.ToAttestation(cm.TipState(), sk),
-			},
-		}
-
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn2}); err != nil {
-			t.Fatal(err)
-		}
-
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
-	})
-
-	t.Run("arbitrary data + attestation", func(t *testing.T) {
-		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		cm := chain.NewManager(store, tipState)
-		ms := newMemState()
-
-		// mine until a utxo is spendable
-		mineBlocks(t, cm, int(n.MaturityDelay)+1)
-		ms.Sync(t, cm)
-
-		sk := types.GeneratePrivateKey()
-		ann := chain.V2HostAnnouncement{
-			{Address: "foo.bar:1234", Protocol: "tcp"},
-		}
-		txn := types.V2Transaction{
-			ArbitraryData: frand.Bytes(16),
-			Attestations: []types.Attestation{
-				ann.ToAttestation(cm.TipState(), sk),
-			},
-		}
-
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn}); err != nil {
-			t.Fatal(err)
-		}
-
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
-
-		txn2 := types.V2Transaction{
-			Attestations: []types.Attestation{
-				ann.ToAttestation(cm.TipState(), sk),
-			},
-		}
-
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn2}); err != nil {
-			t.Fatal(err)
-		}
-
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
-	})
-
-	t.Run("arbitrary data + attestation + change output", func(t *testing.T) {
-		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		cm := chain.NewManager(store, tipState)
-		ms := newMemState()
-
-		// mine until a utxo is spendable
-		mineBlocks(t, cm, int(n.MaturityDelay)+1)
-		ms.Sync(t, cm)
-
-		sk := types.GeneratePrivateKey()
-		ann := chain.V2HostAnnouncement{
-			{Address: "foo.bar:1234", Protocol: "tcp"},
-		}
 		se := ms.SpendableElement(t)
 		minerFee := types.Siacoins(1)
 		txn := types.V2Transaction{
@@ -290,22 +199,15 @@ func TestV2Attestations(t *testing.T) {
 
 		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn}); err != nil {
 			t.Fatal(err)
+		} else if len(cm.V2PoolTransactions()) != 1 {
+			t.Fatalf("expected 1 transaction in pool, got %v", len(cm.V2PoolTransactions()))
 		}
 
 		mineBlocks(t, cm, 1)
 		ms.Sync(t, cm)
 
-		txn2 := types.V2Transaction{
-			Attestations: []types.Attestation{
-				ann.ToAttestation(cm.TipState(), sk),
-			},
+		if len(cm.V2PoolTransactions()) != 0 {
+			t.Fatalf("expected pool to be empty after transaction was mined, got %v", len(cm.V2PoolTransactions()))
 		}
-
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn2}); err != nil {
-			t.Fatal(err)
-		}
-
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
 	})
 }

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -167,47 +167,74 @@ func TestV2Attestations(t *testing.T) {
 	})
 
 	// A funded transaction carrying an attestation and arbitrary data (the host
-	// announcement flow) must still be accepted, and because it spends an input
-	// it must leave the pool once it is mined.
-	t.Run("accepts funded announcement transaction", func(t *testing.T) {
-		store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		cm := chain.NewManager(store, tipState)
-		ms := newMemState()
+	// announcement flow) must still be accepted, mined, and, because it spends
+	// an input, leave the pool once it is confirmed. Both the change-output and
+	// whole-input-as-fee shapes are exercised.
+	spend := map[string]func(se types.SiacoinElement) ([]types.SiacoinOutput, types.Currency){
+		"change output": func(se types.SiacoinElement) ([]types.SiacoinOutput, types.Currency) {
+			minerFee := types.Siacoins(1)
+			return []types.SiacoinOutput{{Address: addr, Value: se.SiacoinOutput.Value.Sub(minerFee)}}, minerFee
+		},
+		"no change output": func(se types.SiacoinElement) ([]types.SiacoinOutput, types.Currency) {
+			return nil, se.SiacoinOutput.Value
+		},
+	}
+	for name, fundTxn := range spend {
+		t.Run("accepts funded announcement transaction ("+name+")", func(t *testing.T) {
+			store, tipState, err := chain.NewDBStore(chain.NewMemDB(), n, genesisBlock, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cm := chain.NewManager(store, tipState)
+			ms := newMemState()
 
-		// mine until a utxo is spendable
-		mineBlocks(t, cm, int(n.MaturityDelay)+1)
-		ms.Sync(t, cm)
+			// mine until a utxo is spendable
+			mineBlocks(t, cm, int(n.MaturityDelay)+1)
+			ms.Sync(t, cm)
 
-		se := ms.SpendableElement(t)
-		minerFee := types.Siacoins(1)
-		txn := types.V2Transaction{
-			SiacoinInputs: []types.V2SiacoinInput{
-				{Parent: se.Copy(), SatisfiedPolicy: types.SatisfiedPolicy{Policy: policy}},
-			},
-			SiacoinOutputs: []types.SiacoinOutput{
-				{Address: addr, Value: se.SiacoinOutput.Value.Sub(minerFee)},
-			},
-			MinerFee:      minerFee,
-			ArbitraryData: frand.Bytes(16),
-			Attestations: []types.Attestation{
-				ann.ToAttestation(cm.TipState(), sk),
-			},
-		}
+			se := ms.SpendableElement(t)
+			outputs, minerFee := fundTxn(se)
+			txn := types.V2Transaction{
+				SiacoinInputs: []types.V2SiacoinInput{
+					{Parent: se.Copy(), SatisfiedPolicy: types.SatisfiedPolicy{Policy: policy}},
+				},
+				SiacoinOutputs: outputs,
+				MinerFee:       minerFee,
+				ArbitraryData:  frand.Bytes(16),
+				Attestations: []types.Attestation{
+					ann.ToAttestation(cm.TipState(), sk),
+				},
+			}
 
-		if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn}); err != nil {
-			t.Fatal(err)
-		} else if len(cm.V2PoolTransactions()) != 1 {
-			t.Fatalf("expected 1 transaction in pool, got %v", len(cm.V2PoolTransactions()))
-		}
+			if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn}); err != nil {
+				t.Fatal(err)
+			} else if len(cm.V2PoolTransactions()) != 1 {
+				t.Fatalf("expected 1 transaction in pool, got %v", len(cm.V2PoolTransactions()))
+			}
 
-		mineBlocks(t, cm, 1)
-		ms.Sync(t, cm)
+			// the transaction must actually be included in the next block
+			b, ok := coreutils.MineBlock(cm, addr, 5*time.Second)
+			if !ok {
+				t.Fatal("failed to mine block")
+			}
+			mined := false
+			for _, mtxn := range b.V2Transactions() {
+				if mtxn.ID() == txn.ID() {
+					mined = true
+					break
+				}
+			}
+			if !mined {
+				t.Fatal("expected transaction to be included in the mined block")
+			} else if err := cm.AddBlocks([]types.Block{b}); err != nil {
+				t.Fatal(err)
+			}
+			ms.Sync(t, cm)
 
-		if len(cm.V2PoolTransactions()) != 0 {
-			t.Fatalf("expected pool to be empty after transaction was mined, got %v", len(cm.V2PoolTransactions()))
-		}
-	})
+			// and it must leave the pool now that its input has been spent
+			if len(cm.V2PoolTransactions()) != 0 {
+				t.Fatalf("expected pool to be empty after transaction was mined, got %v", len(cm.V2PoolTransactions()))
+			}
+		})
+	}
 }

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -134,7 +134,7 @@ func TestV2Attestations(t *testing.T) {
 		{Address: "foo.bar:1234", Protocol: "tcp"},
 	}
 
-	// A transaction that spends no consensus elements stays valid forever and
+	// a transaction that spends no consensus elements stays valid forever and
 	// would be mined in every block, so the txpool must reject it regardless of
 	// any attestations or arbitrary data it carries.
 	t.Run("rejects transactions that spend no elements", func(t *testing.T) {
@@ -166,7 +166,7 @@ func TestV2Attestations(t *testing.T) {
 		}
 	})
 
-	// A funded transaction carrying an attestation and arbitrary data (the host
+	// a funded transaction carrying an attestation and arbitrary data (the host
 	// announcement flow) must still be accepted, mined, and, because it spends
 	// an input, leave the pool once it is confirmed. Both the change-output and
 	// whole-input-as-fee shapes are exercised.

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -858,6 +858,13 @@ func checkFileContractRevisions(txns []types.V2Transaction) error {
 	return nil
 }
 
+func spendsElement(txn types.V2Transaction) bool {
+	return len(txn.SiacoinInputs) > 0 ||
+		len(txn.SiafundInputs) > 0 ||
+		len(txn.FileContractRevisions) > 0 ||
+		len(txn.FileContractResolutions) > 0
+}
+
 func checkEphemeralOutputs(txns []types.V2Transaction) error {
 	sces := make(map[types.SiacoinOutputID]types.SiacoinOutput)
 	for _, txn := range txns {
@@ -1241,6 +1248,11 @@ func (m *Manager) checkTxnSet(txns []types.Transaction, v2txns []types.V2Transac
 		ms.ApplyTransaction(txn, ts)
 	}
 	for _, txn := range v2txns {
+		// reject any v2 transactions that don't spend any elements as they won't be removed from
+		// the pool when they are confirmed
+		if !spendsElement(txn) {
+			return false, fmt.Errorf("v2 transaction %v does not spend any elements", txn.ID())
+		}
 		if _, ok := m.txpool.indices[txn.ID()]; !ok {
 			allInPool = false
 		}

--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -32,6 +32,30 @@ func findBlockNonce(cs consensus.State, b *types.Block) {
 	}
 }
 
+func TestSpendsElement(t *testing.T) {
+	tests := []struct {
+		name string
+		txn  types.V2Transaction
+		want bool
+	}{
+		{"empty", types.V2Transaction{}, false},
+		{"arbitrary data only", types.V2Transaction{ArbitraryData: frand.Bytes(16)}, false},
+		{"attestation only", types.V2Transaction{Attestations: []types.Attestation{{}}}, false},
+		{"file contract creation only", types.V2Transaction{FileContracts: []types.V2FileContract{{}}}, false},
+		{"siacoin input", types.V2Transaction{SiacoinInputs: []types.V2SiacoinInput{{}}}, true},
+		{"siafund input", types.V2Transaction{SiafundInputs: []types.V2SiafundInput{{}}}, true},
+		{"file contract revision", types.V2Transaction{FileContractRevisions: []types.V2FileContractRevision{{}}}, true},
+		{"file contract resolution", types.V2Transaction{FileContractResolutions: []types.V2FileContractResolution{{}}}, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := spendsElement(test.txn); got != test.want {
+				t.Fatalf("spendsElement = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestManager(t *testing.T) {
 	n, genesisBlock := TestnetZen()
 

--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -56,6 +56,83 @@ func TestSpendsElement(t *testing.T) {
 	}
 }
 
+// TestRevertedNoElementTransaction exercises the reverted-transaction re-add
+// path with a v2 transaction that spends no elements. The transaction is mined
+// directly into a block, bypassing pool admission, then reverted by a reorg.
+// It must not re-enter the pool via lastRevertedV2.
+func TestRevertedNoElementTransaction(t *testing.T) {
+	n, genesisBlock := TestnetZen()
+
+	n.InitialTarget = types.BlockID{0xFF}
+	n.HardforkDevAddr.Height = 0
+	n.HardforkTax.Height = 0
+	n.HardforkStorageProof.Height = 0
+	n.HardforkOak.Height = 0
+	n.HardforkOak.FixHeight = 0
+	n.HardforkASIC.Height = 0
+	n.HardforkFoundation.Height = 0
+	n.HardforkV2.AllowHeight = 0
+
+	store, tipState, err := NewDBStore(NewMemDB(), n, genesisBlock, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cm := NewManager(store, tipState)
+
+	txn := types.V2Transaction{ArbitraryData: frand.Bytes(16)}
+
+	// the admission path rejects it
+	if _, err := cm.AddV2PoolTransactions(cm.Tip(), []types.V2Transaction{txn}); err == nil || !strings.Contains(err.Error(), "does not spend any elements") {
+		t.Fatal("unexpected", err)
+	}
+
+	mine := func(cs consensus.State, v2txns []types.V2Transaction) (types.Block, consensus.State) {
+		b := types.Block{
+			ParentID:  cs.Index.ID,
+			Timestamp: types.CurrentTimestamp(),
+			MinerPayouts: []types.SiacoinOutput{{
+				Value:   cs.BlockReward(),
+				Address: types.Address(frand.Entropy256()),
+			}},
+		}
+		if v2txns != nil {
+			b.V2 = &types.V2BlockData{
+				Height:       cs.Index.Height + 1,
+				Transactions: v2txns,
+				Commitment:   cs.Commitment(b.MinerPayouts[0].Address, b.Transactions, v2txns),
+			}
+		}
+		findBlockNonce(cs, &b)
+		ancestorTimestamp, _ := store.AncestorTimestamp(b.ParentID)
+		cs, _ = consensus.ApplyBlock(cs, b, store.SupplementTipBlock(b), ancestorTimestamp)
+		return b, cs
+	}
+
+	// build a fork of two empty blocks off the genesis tip
+	fork1, forkState := mine(cm.TipState(), nil)
+	fork2, _ := mine(forkState, nil)
+
+	// mine the transaction directly into a block; consensus accepts it
+	b, _ := mine(cm.TipState(), []types.V2Transaction{txn})
+	if err := cm.AddBlocks([]types.Block{b}); err != nil {
+		t.Fatal(err)
+	} else if len(cm.V2PoolTransactions()) != 0 {
+		t.Fatal("unexpected pool size", len(cm.V2PoolTransactions()))
+	}
+
+	// trigger a reorg that reverts the block containing the transaction
+	if err := cm.AddBlocks([]types.Block{fork1, fork2}); err != nil {
+		t.Fatal(err)
+	} else if cm.Tip().ID != fork2.ID() {
+		t.Fatal("reorg failed")
+	}
+
+	// the reverted transaction must not re-enter the pool
+	if _, ok := cm.V2PoolTransaction(txn.ID()); ok {
+		t.Fatal("no-element transaction re-entered the pool after reorg")
+	}
+}
+
 func TestManager(t *testing.T) {
 	n, genesisBlock := TestnetZen()
 


### PR DESCRIPTION
Rejects any transaction that doesn't spend an element from being added to the transaction pool.